### PR TITLE
fix to support korganizer 

### DIFF
--- a/kronolith/lib/Event.php
+++ b/kronolith/lib/Event.php
@@ -844,6 +844,7 @@ abstract class Kronolith_Event
             }
             if ($exdates) {
                 $vEvent->setAttribute('EXDATE', $exdates);
+                $vEvent->setAttribute('EXDATE', $exdates, array("VALUE" => "DATE"));
             }
         }
         array_unshift($vEvents, $vEvent);


### PR DESCRIPTION
Hi,

I encountered some problems concerning korganizer and EXDATE:
My korganizer (version 4.4.11) recognizes EXDATE only if it is explicit typed, eg
  EXDATE;VALUE=DATE:20120223
instead of
EXDATE:20120223T000000Z

I don't know how far this is related to Pull-Request #11.

I understand horde as some kind of middleware to glue different components together, so I left the original property in place to achieve maximum compatibility (without violating the rfc as far as I know). I'd be glad if you put this upstream.

Thanks,
Manuel
