### PR TITLE
fixed an issue with RDATE in timezone definitions

### DIFF
--- a/framework/Icalendar/lib/Horde/Icalendar/Vtimezone.php
+++ b/framework/Icalendar/lib/Horde/Icalendar/Vtimezone.php
@@ -68,11 +68,31 @@ class Horde_Icalendar_Vtimezone extends Horde_Icalendar
         }
 
         try {
+            $rdates = $child->getAttribute('RDATE');
+        } catch (Horde_Icalendar_Exception $e) {
+            $rdates = false;
+        }
+
+        try {
             $rrules = $child->getAttribute('RRULE');
         } catch (Horde_Icalendar_Exception $e) {
             if (!is_int($switch_time)) {
                 return false;
             }
+
+            if ($rdates !== false) {
+                $rdate_match = false;
+                foreach ($rdates as $rdate) {
+                    $t = getdate($rdate);
+                    if ($t['year'] == $year) {
+                        $rdate_match = true;
+                    }
+                }
+                if (!$rdate_match) {
+                    return false;
+                }
+            }
+
             // Convert this timestamp from local time to UTC for
             // comparison (All dates are compared as if they are UTC).
             $t = getdate($switch_time);


### PR DESCRIPTION
Hi,

afaik the RFC allows RDATE in VTIMEZONE definitions. In case of no RRULE and some RDATEs not in the objects year, the timezone component applied the dtstart - which is wrong: I think it should return 'false' as the timezone component doesn't match in this case.

Yours,
Manuel
