### PR TITLE
Correct and add commonly misspelled numbers

### DIFF
--- a/framework/Support/lib/Horde/Support/Numerizer/Locale/Base.php
+++ b/framework/Support/lib/Horde/Support/Numerizer/Locale/Base.php
@@ -44,12 +44,14 @@ class Horde_Support_Numerizer_Locale_Base
     public $TEN_PREFIXES = array(
         'twenty' => 20,
         'thirty' => 30,
-        'fourty' => 40,
+        'forty' => 40,
+        'fourty' => 40, // Common mis-spelling
         'fifty' => 50,
         'sixty' => 60,
         'seventy' => 70,
         'eighty' => 80,
         'ninety' => 90,
+        'ninty' => 90, // Common mis-spelling
     );
 
     public $BIG_PREFIXES = array(

--- a/framework/Support/test/Horde/Support/Numerizer/Locale/BaseTest.php
+++ b/framework/Support/test/Horde/Support/Numerizer/Locale/BaseTest.php
@@ -59,6 +59,14 @@ class Horde_Support_Numerizer_Locale_BaseTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testMissspelledForty()
+    {
+        $numerizer = Horde_Support_Numerizer::factory();
+
+        $this->assertEquals(40, $numerizer->numerize('forty'));
+        $this->assertEquals(40, $numerizer->numerize('fourty'));
+    }
+
     public function testLeavesDatesAlone()
     {
         $numerizer = Horde_Support_Numerizer::factory();


### PR DESCRIPTION
Forty/fourty & ninety/ninty added to the base locale dictionary.
