### PR TITLE
Horde PGP: Fix retrieval of pgp keys, when multiple keys are found on a server.

### DIFF
--- a/framework/Crypt/lib/Horde/Crypt/Pgp.php
+++ b/framework/Crypt/lib/Horde/Crypt/Pgp.php
@@ -833,8 +833,10 @@ class Horde_Crypt_Pgp extends Horde_Crypt
         if (strpos($output, '-----BEGIN PGP PUBLIC KEY BLOCK') !== false) {
             $pubkey = $output;
         } elseif (strpos($output, 'pub:') !== false) {
-            $output = explode("\n", $output);
-            $keyids = array();
+            $output  = explode("\n", $output);
+            $keyids  = array();
+            $keyuids = array();
+            $curid;
             foreach ($output as $line) {
                 if (substr($line, 0, 4) == 'pub:') {
                     $line = explode(':', $line);
@@ -843,7 +845,24 @@ class Horde_Crypt_Pgp extends Horde_Crypt
                         (!empty($line[5]) && $line[5] <= time())) {
                         continue;
                     }
-                    $keyids[$line[4]] = $line[1];
+                    $curid          = $line[4];
+                    $keyids[$curid] = $line[1];
+                } elseif (isset($curid) && substr($line, 0, 4) == 'uid:') {
+                    preg_match("/<([^>]+)>/", $line, $matches);
+                    $keyuids[$curid][] = $matches[1];
+                }
+            }
+            /* Remove keys without a matching uid */
+            foreach ($keyuids as $id => $uids) {
+                $match = false;
+                foreach ($uids as $uid) {
+                    if($uid == $address) {
+                        $match = true;
+                        break;
+                    }
+                }
+                if(!$match) {
+                    unset($keyids[$id]);
                 }
             }
             /* Sort by timestamp to use the newest key. */


### PR DESCRIPTION
1. When multiple keys are found, the request to fetch the actual key would end up at a wrong keyserver.
2. Keys with different email addresses might be found, who need to be ignored.

see ticket #11380
