### PR TITLE
Use rather horde's tmpdir than a fixed directory

### DIFF
--- a/framework/Rpc/lib/Horde/Rpc/Syncml.php
+++ b/framework/Rpc/lib/Horde/Rpc/Syncml.php
@@ -35,7 +35,7 @@ class Horde_Rpc_Syncml extends Horde_Rpc
         $backendparms = array(
             /* Write debug output to this dir, must be writeable be web
              * server. */
-            'debug_dir' => '/tmp/sync',
+            'debug_dir' => Horde::getTempDir().'/sync',
             /* Log all (wb)xml packets received or sent to debug_dir. */
             'debug_files' => true,
             /* Log everything. */

--- a/framework/SyncMl/test/Horde/SyncMl/testsync.php
+++ b/framework/SyncMl/test/Horde/SyncMl/testsync.php
@@ -41,7 +41,7 @@ define('SYNCMLTEST_USERNAME', 'syncmltest');
 $syncml_backend_driver = 'Horde';
 $syncml_backend_parms = array(
     /* debug output to this dir, must be writeable be web server: */
-    'debug_dir' => '/tmp/sync',
+    'debug_dir' => Horde::getTempDir().'/sync',
     /* log all (wb)xml packets received or sent to debug_dir: */
     'debug_files' => true,
     /* Log everything: */


### PR DESCRIPTION
It might be possible that the webserver is not allowed to go into
/tmp (openbasedir restriction), so we should rather use what the
config tells us to use.
