### PR TITLE
Add sslv2 sslv3 options to the "secure" parameter.

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
@@ -462,7 +462,9 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
 
         switch ($this->_params['secure']) {
         case 'ssl':
-            $conn = 'ssl://';
+        case 'sslv2':
+        case 'sslv3':
+            $conn = $this->_params['secure'] . '://';
             $this->_isSecure = true;
             break;
 


### PR DESCRIPTION
Sometimes it is needed to force the SSL version when connecting to a server.

See: https://bugs.php.net/bug.php?id=29296
