### PR TITLE
Fix Horde_Share: test fails (Bug #11966)

### DIFF
--- a/framework/Share/test/Horde/Share/Base.php
+++ b/framework/Share/test/Horde/Share/Base.php
@@ -585,7 +585,7 @@ class Horde_Share_Test_Base extends Horde_Test_Case
         $this->assertArrayHasKey('joeshare', self::$share->listAllShares());
     }
 
-    public function callback($share)
+    public function callbackSetShareOb($share)
     {
         $share->setShareOb(new Horde_Support_Stub());
         $this->assertEquals($share, unserialize(serialize($share)));

--- a/framework/Share/test/Horde/Share/Kolab/MockTest.php
+++ b/framework/Share/test/Horde/Share/Kolab/MockTest.php
@@ -231,7 +231,7 @@ class Horde_Share_Kolab_MockTest extends Horde_Share_Test_Base
 
     public function testCallback()
     {
-        $this->callback(new Horde_Share_Object_Sql(array()));
+        $this->callbackSetShareOb(new Horde_Share_Object_Sql(array()));
     }
 
     protected function switchAuth($user)

--- a/framework/Share/test/Horde/Share/Sql/Base.php
+++ b/framework/Share/test/Horde/Share/Sql/Base.php
@@ -184,7 +184,7 @@ class Horde_Share_Test_Sql_Base extends Horde_Share_Test_Base
 
     public function testCallback()
     {
-        $this->callback(new Horde_Share_Object_Sql(array()));
+        $this->callbackSetShareOb(new Horde_Share_Object_Sql(array()));
     }
 
     public static function setUpBeforeClass()

--- a/framework/Share/test/Horde/Share/Sqlng/Base.php
+++ b/framework/Share/test/Horde/Share/Sqlng/Base.php
@@ -185,7 +185,7 @@ class Horde_Share_Test_Sqlng_Base extends Horde_Share_Test_Base
 
     public function testCallback()
     {
-        parent::callback(new Horde_Share_Object_Sqlng(array()));
+        $this->callbackSetShareOb(new Horde_Share_Object_Sqlng(array()));
     }
 
     public static function setUpBeforeClass()


### PR DESCRIPTION
Rename Horde_Share_Test_Base::callback() to callbackSetShareOb()
Avoid name conflict with PHPUnit_Framework_Assert::callback()
