### PR TITLE
fix gpg key retrieval

### DIFF
--- a/framework/Crypt/lib/Horde/Crypt/Pgp.php
+++ b/framework/Crypt/lib/Horde/Crypt/Pgp.php
@@ -838,7 +838,7 @@ class Horde_Crypt_Pgp extends Horde_Crypt
                     $curid = $line[4];
                     $keyids[$curid] = $line[1];
                 } elseif (!is_null($curid) && substr($line, 0, 4) == 'uid:') {
-                    preg_match("/>([^>]+)>/", $line, $matches);
+                    preg_match("/<([^>]+)>/", $line, $matches);
                     $keyuids[$curid][] = $matches[1];
                 }
             }


### PR DESCRIPTION
getting gpg keys from key-servers is still broken in the latest release (see Bug #11380).

the problem is, that email addresses are not correctly extracted from the received keys list, thus all keys are rejected.

commit 425bcf0cf8e5686fe273ff9345be1e06bf5a487b incorectly copy/pasted the solution from my original pull request. this commit fixes the copy/paste error.

just a comment: how would i add tests for this part of the code
