### PR TITLE
Fix Null session fail when session/max_time

### DIFF
--- a/framework/Core/lib/Horde/Session/Null.php
+++ b/framework/Core/lib/Horde/Session/Null.php
@@ -25,6 +25,8 @@
  */
 class Horde_Session_Null extends Horde_Session
 {
+    public $begin = null;
+
     /**
      * Constructor.
      */
@@ -61,6 +63,9 @@ class Horde_Session_Null extends Horde_Session
         $this->_active = true;
         session_write_close();
 
+        // Set a beginning to pass authentication timeout checks
+        $this->begin = time();
+        
         register_shutdown_function(array($this, 'destroy'));
     }
 


### PR DESCRIPTION
Null Sessions didn't have a beginning set. In combination with a
$conf['session']['max_time'] being set this caused
Registry::checkExistingAuth to fail.

fixes http://bugs.horde.org/ticket/12078
