### PR TITLE
Turba: create also URLs for entities

### DIFF
--- a/turba/lib/Api.php
+++ b/turba/lib/Api.php
@@ -1345,6 +1345,26 @@ class Turba_Api extends Horde_Registry_Api
     }
 
     /**
+     * Creates a URL for a contact retrieved from
+     * getAllAttributeValues
+     *
+     * @param string $uid   ID consisting of source:objectId
+     *
+     * @return Horde::url  A url representing the contact
+     */
+    public function getContactUrl($uid = '')
+    {
+	    global $registry;
+
+	    preg_match('/^(.+):(.+)$/', $uid, $match);
+	    $url = Horde::url($registry->link('contacts/show', array(
+	    	'source' => $match[1],
+		'key' => $match[2])),
+		true);
+	    return $url;
+    }
+ 
+    /**
      * Retrieves a list of available time objects categories.
      *
      * @return array  An array of all configured time object categories.


### PR DESCRIPTION
We don't want to parse the id notation by ourselves, so we decided to integrate the parser into horde in order to get it maintained upstream.

Please tell me if you will accept that feature or not. If you will reject, I will rather use the workaround logic in my own module to keep patching effort minimal.
