### PR TITLE
make default pgp keylength konfigurable

### DIFF
--- a/imp/config/conf.xml
+++ b/imp/config/conf.xml
@@ -219,4 +219,18 @@
    support?">true</configboolean>
   </configsection>
  </configtab>
+ 
+ <configtab name="pgp" desc="PGP Settings">
+  <configsection name="pgp">
+   <configswitch name="default_keylength" desc="The preselected keylength
+    when a user generates a new PGP keypair. GnuPG currently advocates the 
+    creation of 2048 bit keys. The default for Horde is set to 1024 due to the 
+    special situation when creating PGP keys on a server: the creation might
+    timeout and deplete your random pool.">1024
+    <case name="1024" desc="1024" />
+    <case name="2048" desc="2048" />
+    <case name="4096" desc="4096" />
+   </configswitch>
+  </configsection>
+ </configtab>
 </configuration>

--- a/imp/lib/Prefs/Special/PgpPrivateKey.php
+++ b/imp/lib/Prefs/Special/PgpPrivateKey.php
@@ -24,7 +24,7 @@ class IMP_Prefs_Special_PgpPrivateKey implements Horde_Core_Prefs_Ui_Special
      */
     public function display(Horde_Core_Prefs_Ui $ui)
     {
-        global $injector, $page_output, $prefs, $session;
+        global $injector, $page_output, $prefs, $session, $conf;
 
         $page_output->addScriptPackage('IMP_Script_Package_Imp');
 
@@ -77,6 +77,9 @@ class IMP_Prefs_Special_PgpPrivateKey implements Horde_Core_Prefs_Ui_Special
                 $imp_identity = $injector->getInstance('IMP_Identity');
                 $view->fullname = $imp_identity->getFullname();
                 $view->fromaddr = $imp_identity->getFromAddress()->bare_address;
+                if (!empty($conf['pgp']['default_keylength'])) {
+                  $view->default_keylength = $conf['pgp']['default_keylength'];
+                } 
 
                 $page_output->addInlineScript(array(
                     '$("create_pgp_key").observe("click", function(e) { if (!window.confirm(' . Horde_Serialize::serialize(_("Key generation may take a long time to complete.  Continue with key generation?"), Horde_Serialize::JSON, 'UTF-8') . ')) { e.stop(); } })'

--- a/imp/templates/prefs/pgpprivatekey.html.php
+++ b/imp/templates/prefs/pgpprivatekey.html.php
@@ -88,8 +88,9 @@
     </td>
     <td>
      <select id="generate_keylength" name="generate_keylength">
-      <option value="1024">1024</option>
-      <option value="2048">2048</option>
+      <option value="1024"<?php if($this->default_keylength == 1024){echo 'selected';} ?>>1024</option>
+      <option value="2048"<?php if($this->default_keylength == 2048){echo 'selected';} ?>>2048</option>
+      <option value="4096"<?php if($this->default_keylength == 4096){echo 'selected';} ?>>4096</option>
      </select>
     </td>
     <td>


### PR DESCRIPTION
When users create new keys they usually don't consciously choose a
key length, but instead just keep the default one. Unfortunately the
current default of 1024 is not considered a sustainable choice anymore.
(http://en.wikipedia.org/wiki/Key_size#Asymmetric_algorithm_key_lengths)

Unfortunately setting a bigger default might not be possible in many
cases, since servers usually don't have an overflowing random pool and
also timeouts in place which might interfere with prolonged key generation.

Therefore we leave the default to be 1024, but add a config switch to
let the admin decide, if a bigger keylength can be chosen in the
particular case.

Additionally add 4096 as a new option, since it is also commonly used.
