### PR TITLE
force sessions to timeout

### DIFF
--- a/framework/Core/lib/Horde/Registry.php
+++ b/framework/Core/lib/Horde/Registry.php
@@ -2521,6 +2521,12 @@ class Horde_Registry
             return false;
         }
 
+        if (!empty($conf['session']['timeout']) &&
+            (($conf['session']['timeout'] + $session->modified) < time())) {
+            $auth->setError(Horde_Core_Auth_Application::REASON_SESSIONMAXTIME);
+            return false;
+        }
+        
         if (!empty($conf['session']['max_time']) &&
             (($conf['session']['max_time'] + $session->begin) < time())) {
             $auth->setError(Horde_Core_Auth_Application::REASON_SESSIONMAXTIME);

--- a/framework/Core/lib/Horde/Session/Null.php
+++ b/framework/Core/lib/Horde/Session/Null.php
@@ -68,6 +68,7 @@ class Horde_Session_Null extends Horde_Session
     {
         $this->_active = true;
         $this->_data[Horde_Session::BEGIN] = time();
+        $this->_data[Horde_Session::MODIFIED] = time();
     }
 
     /**


### PR DESCRIPTION
Currently horde relies on session.gc_maxlifetime only to
enforce session timeouts.

Especially on systems where gc_probability needs to be low for
performance reasons or on low traffic servers this is a serious
problem, since sessions might be significantly longer valid, than it was
intended by the admin when he sets conf['session']['timeout'].

Therefore we should always check the last modification of the
session and deny authentication if the session should have timeouted.
