### PR TITLE
Invalidate Zend OPcache to ensure saved version used

### DIFF
--- a/framework/Core/lib/Horde/Config.php
+++ b/framework/Core/lib/Horde/Config.php
@@ -299,6 +299,10 @@ class Horde_Config
             fclose($fp);
             $GLOBALS['registry']->rebuild();
             $GLOBALS['notification']->push(sprintf(Horde_Core_Translation::t("Successfully wrote %s"), Horde_Util::realPath($configFile)), 'horde.success');
+            if (function_exists('opcache_invalidate')) {
+                /* Invalidate Zend OPcache to ensure saved version used */
+                opcache_invalidate($configFile, true);
+            }
             return true;
         }
 


### PR DESCRIPTION
Zend OPcache will be the default / official opcode cache in PHP 5.5.

It is also available as a pecl extension for PHP 5.3 and 5.4.
http://pecl.php.net/package/ZendOpcache

According to configuration, script files could be check for modification, based on timestamp, after a small time (default = 2") or never (optimisation for production server where scripts are not supposed to change)

This minor patch invalidate the cache of the config script, so ensure the new version will be used on next execution.

The opcache_invalidate function is part of php 5.5.0beta3 and will be in the pecl extension version 7.0.2 (code are synced)
