### PR TITLE
Full Kolab Horde_History support

### DIFF
--- a/framework/Core/lib/Horde/Core/Factory/KolabStorage.php
+++ b/framework/Core/lib/Horde/Core/Factory/KolabStorage.php
@@ -109,6 +109,13 @@ class Horde_Core_Factory_KolabStorage extends Horde_Core_Factory_Base
             'cache' => $this->_injector->getInstance('Horde_Cache'),
         );
 
+        // Check if the history system is enabled
+        try {
+            $history = $this->_injector->getInstance('Horde_History');
+            $params['history'] = $history;
+        } catch(Horde_Exception $e) {
+        }
+
         $factory = new Horde_Kolab_Storage_Factory($params);
         return $factory->create();
     }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Cached.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Cached.php
@@ -7,6 +7,7 @@
  * @category Kolab
  * @package  Kolab_Storage
  * @author   Gunnar Wrobel <wrobel@pardus.de>
+ * @author   Thomas Jarosch <thomas.jarosch@intra2net.com>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @link     http://pear.horde.org/index.php?package=Kolab_Storage
  */
@@ -22,6 +23,7 @@
  * @category Kolab
  * @package  Kolab_Storage
  * @author   Gunnar Wrobel <wrobel@pardus.de>
+ * @author   Thomas Jarosch <thomas.jarosch@intra2net.com>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @link     http://pear.horde.org/index.php?package=Kolab_Storage
  */
@@ -226,8 +228,14 @@ extends Horde_Kolab_Storage_Data_Base
             return;
         }
         $previous = unserialize($this->_data_cache->getStamp());
-        if ($previous === false || $previous->isReset($current)) {
-            $this->_completeSynchronization($current);
+
+        // check if UIDVALIDITY changed
+        $is_reset = false;
+        if ($previous !== false)
+            $is_reset = $previous->isReset($current);
+
+        if ($previous === false || $is_reset) {
+            $this->_completeSynchronization($current, array('is_reset' => $is_reset));
             return;
         }
         if (!isset($params['changes'])) {

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -31,6 +31,13 @@ class Horde_Kolab_Storage_Data_Query_History_Base
 implements Horde_Kolab_Storage_Data_Query_History
 {
     /**
+     * The factory for generating additional resources.
+     *
+     * @var Horde_Kolab_Storage_Factory
+     */
+    protected $factory;
+
+    /**
      * The queriable data.
      *
      * @var Horde_Kolab_Storage_Data
@@ -54,7 +61,8 @@ implements Horde_Kolab_Storage_Data_Query_History
                                 $params)
     {
         $this->data = $data;
-        $this->history = $params['factory']->createHistory($data->getAuth());
+        $this->factory = $params['factory'];
+        $this->history = $this->factory->createHistory($data->getAuth());
     }
 
     /**

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -170,30 +170,34 @@ implements Horde_Kolab_Storage_Data_Query_History
         if (!empty($this->_prefix))
             return $this->_prefix;
 
-        $type = $this->_type2app($this->data->getType());
-        if (empty($type)) {
+        $app = $this->_type2app($this->data->getType());
+        if (empty($app)) {
             Horde::log('Unsupported app type: ' . $this->data->getType(), 'WARN');
             return '';
         }
 
-        // Determine share name
-        $share_name = '';
+        // Determine share id
         $folder = $this->data->getPath();
+        $share_id = '';
 
-        // TODO: Access global Kolab_Storage object if possible
-        // We probably have to extend the class structure for this.
-        $query = $this->factory->create()->getList()
-                ->getQuery(Horde_Kolab_Storage_List_Tools::QUERY_SHARE);
+        // Create a share instance. The performance impact is minimal
+        // since the "real" app will create a share instance anyway.
+        $shares = $GLOBALS['injector']->getInstance('Horde_Core_Factory_Share')->create($app);
+        $all_shares = $shares->listAllShares();
+        foreach($all_shares as $id => $share) {
+            if ($share->get('folder') == $folder) {
+                $share_id = $id;
+                break;
+            }
+        }
 
-        $data = $query->getParameters($folder);
-        if (isset($data['share_name']))
-            $share_name = $data['share_name'];
-        else {
-            Horde::log("share_name not found. Can't compute history prefix for folder " . $folder, 'ERR');
+        // bail out if we are unable to determine the share id
+        if (empty($share_id)) {
+            Horde::log("share_id not found. Can't compute history prefix for folder " . $folder, 'ERR');
             return '';
         }
 
-        $this->_prefix = $type.':'.$share_name.':';
+        $this->_prefix = $app.':'.$share_id.':';
 
         return $this->_prefix;
     }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -227,14 +227,10 @@ implements Horde_Kolab_Storage_Data_Query_History
                 $object, array('action' => 'add', 'bid' => $bid), true
             );
         } else {
-            $last = array('ts' => 0);
+            $last = array('modseq' => 0, 'action' => 'unknown');
             foreach ($log as $entry) {
                 $action = $entry['action'];
-                if ($entry['ts'] > $last['ts'] && ($action == 'add' || $action == 'modify' || $action == 'delete')) {
-                    $last = $entry;
-                } else if ($entry['ts'] == $last['ts'] && $action == 'delete') {
-                    // prefer 'delete' actions over other actions if the timestamp is the same.
-                    // see the logic below.
+                if ($entry['modseq'] > $last['modseq'] && ($action == 'add' || $action == 'modify' || $action == 'delete')) {
                     $last = $entry;
                 }
             }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -185,7 +185,8 @@ implements Horde_Kolab_Storage_Data_Query_History
         } else {
             $last = array('ts' => 0);
             foreach ($log as $entry) {
-                if ($entry['ts'] > $last['ts']) {
+                $action = $entry['action'];
+                if ($entry['ts'] > $last['ts'] && ($action == 'add' || $action == 'modify' || $action == 'delete')) {
                     $last = $entry;
                 }
             }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -138,13 +138,18 @@ implements Horde_Kolab_Storage_Data_Query_History
 
         // clean up history database: Mark stale entries as deleted
         $all_entries = $this->history->getByTimestamp('>', 0, array(), $search_prefix);
-        foreach ($all_entries as $full_id => $db_id) {
-            if (isset($seen_objects[$full_id]))
-                continue;
 
-            $this->history->log(
-                $full_id, array('action' => 'delete'), true
-            );
+        foreach ($all_entries as $full_id => $db_id) {
+            if (isset($seen_objects[$full_id])) {
+                continue;
+            }
+
+            $last = $this->history->getLatestEntry($full_id);
+            if ($last === false || $last['action'] != 'delete') {
+                $this->history->log(
+                    $full_id, array('action' => 'delete'), true
+                );
+            }
         }
     }
 
@@ -220,21 +225,13 @@ implements Horde_Kolab_Storage_Data_Query_History
      */
     private function _updateLog($object, $bid, $force=false)
     {
-        $log = $this->history->getHistory($object);
-        if (count($log) == 0) {
+        $last = $this->history->getLatestEntry($object);
+        if ($last === false) {
             // New, unknown object
             $this->history->log(
                 $object, array('action' => 'add', 'bid' => $bid), true
             );
         } else {
-            $last = array('modseq' => 0, 'action' => 'unknown');
-            foreach ($log as $entry) {
-                $action = $entry['action'];
-                if ($entry['modseq'] > $last['modseq'] && ($action == 'add' || $action == 'modify' || $action == 'delete')) {
-                    $last = $entry;
-                }
-            }
-
             // If the last action for this object was 'delete', we issue an 'add'.
             // Objects can vanish and re-appear using the same object uid.
             // (a foreign client is sending an update over a slow link)

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -139,6 +139,9 @@ implements Horde_Kolab_Storage_Data_Query_History
      */
     private function _completeSynchronization($prefix, $is_reset)
     {
+        $folder = $this->data->getPath();
+        Horde::log(sprintf('Performing full history sync for %s (folder: %s, is_reset: %d)', $prefix, $folder, $is_reset), 'INFO');
+
         $seen_objects = array();
         foreach ($this->data->getObjectToBackend() as $object => $bid) {
             $full_id = $prefix.$object;

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -84,26 +84,31 @@ implements Horde_Kolab_Storage_Data_Query_History
      */
     public function synchronize($params = array())
     {
-        $prefix = $this->_constructHistoryPrefix();
-        // Abort history update if we can't determine the prefix.
-        // Otherwise we pollute the database with useless entries.
-        if (empty($prefix)) {
-            return;
-        }
-
         // check if IMAP uidvalidity changed
         $is_reset = !empty($params['is_reset']);
 
         if (isset($params['changes']) && !$is_reset) {
-            foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::ADDED] as $bid => $object) {
+            $added = $params['changes'][Horde_Kolab_Storage_Folder_Stamp::ADDED];
+            $deleted = $params['changes'][Horde_Kolab_Storage_Folder_Stamp::DELETED];
+
+            if (!empty($added) || !empty($deleted)) {
+                $prefix = $this->_constructHistoryPrefix();
+                // Abort history update if we can't determine the prefix.
+                // Otherwise we pollute the database with useless entries.
+                if (empty($prefix)) {
+                    return;
+                }
+            }
+
+            foreach ($added as $bid => $object) {
                 $this->_updateLog($prefix.$object['uid'], $bid);
             }
-            foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::DELETED] as $bid => $object_uid) {
+            foreach ($deleted as $bid => $object_uid) {
                 // Check if the object is really gone from the folder.
                 // Otherwise we just deleted a duplicated object or updated the original one.
                 // (An update results in an ADDED + DELETED folder action)
                 if ($this->data->objectIdExists($object_uid) == true) {
-                    Horde::log('Skipping delete of still existing Kolab object ' . $object_uid, 'INFO');
+                    Horde::log('Skipping delete of still existing Kolab object ' . $object_uid, 'DEBUG');
                     continue;
                 }
 
@@ -112,6 +117,11 @@ implements Horde_Kolab_Storage_Data_Query_History
                 );
             }
         } else {
+            $prefix = $this->_constructHistoryPrefix();
+            if (empty($prefix)) {
+                return;
+            }
+
             // Full sync. Either our timestamp is too old
             // or the IMAP uidvalidity changed
             $this->_completeSynchronization($prefix, $is_reset);

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -8,6 +8,7 @@
  * @category Kolab
  * @package  Kolab_Storage
  * @author   Gunnar Wrobel <wrobel@pardus.de>
+ * @author   Thomas Jarosch <thomas.jarosch@intra2net.com>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @link     http://pear.horde.org/index.php?package=Kolab_Storage
  */
@@ -24,6 +25,7 @@
  * @category Kolab
  * @package  Kolab_Storage
  * @author   Gunnar Wrobel <wrobel@pardus.de>
+ * @author   Thomas Jarosch <thomas.jarosch@intra2net.com>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @link     http://pear.horde.org/index.php?package=Kolab_Storage
  */
@@ -88,10 +90,12 @@ implements Horde_Kolab_Storage_Data_Query_History
         if (empty($prefix))
             return;
 
-        $stamp = $this->data->getStamp();
-        if (isset($params['changes'])) {
+        // check if IMAP uidvalidity changed
+        $is_reset = !empty($params['is_reset']);
+
+        if (isset($params['changes']) && !$is_reset) {
             foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::ADDED] as $bid => $object) {
-                $this->_updateLog($prefix.$object['uid'], $bid, $stamp);
+                $this->_updateLog($prefix.$object['uid'], $bid);
             }
             foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::DELETED] as $bid => $object_uid) {
                 // Check if the object is really gone from the folder.
@@ -101,12 +105,12 @@ implements Horde_Kolab_Storage_Data_Query_History
                     continue;
 
                 $this->history->log(
-                    $prefix.$object_uid, array('action' => 'delete', 'bid' => $bid, 'stamp' => $stamp), true
+                    $prefix.$object_uid, array('action' => 'delete', 'bid' => $bid), true
                 );
             }
         } else {
             foreach ($this->data->getObjectToBackend() as $object => $bid) {
-                $this->_updateLog($prefix.$object, $bid, $stamp);
+                $this->_updateLog($prefix.$object, $bid);
             }
         }
     }
@@ -177,16 +181,16 @@ implements Horde_Kolab_Storage_Data_Query_History
      * @param string                           $object The object ID.
      * @param string                           $bid    The backend ID of
      *                                                 the object.
-     * @param Horde_Kolab_Storage_Folder_Stamp $stamp  The folder stamp.
+     * @param bool                             $force  Force update
      *
      * @return NULL
      */
-    private function _updateLog($object, $bid, $stamp)
+    private function _updateLog($object, $bid, $force=false)
     {
         $log = $this->history->getHistory($object);
         if (count($log) == 0) {
             $this->history->log(
-                $object, array('action' => 'add', 'bid' => $bid, 'stamp' => $stamp), true
+                $object, array('action' => 'add', 'bid' => $bid), true
             );
         } else {
             $last = array('ts' => 0);
@@ -206,14 +210,13 @@ implements Horde_Kolab_Storage_Data_Query_History
             // (a foreign client is sending an update over a slow link)
             if ($last['action'] == 'delete') {
                 $this->history->log(
-                    $object, array('action' => 'add', 'bid' => $bid, 'stamp' => $stamp), true
+                    $object, array('action' => 'add', 'bid' => $bid), true
                 );
             }
 
-            if (!isset($last['bid']) || $last['bid'] != $bid
-                || (isset($last['stamp']) && $last['stamp']->isReset($stamp))) {
+            if (!isset($last['bid']) || $last['bid'] != $bid || $force) {
                 $this->history->log(
-                    $object, array('action' => 'modify', 'bid' => $bid, 'stamp' => $stamp), true
+                    $object, array('action' => 'modify', 'bid' => $bid), true
                 );
             }
         }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -93,9 +93,15 @@ implements Horde_Kolab_Storage_Data_Query_History
             foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::ADDED] as $bid => $object) {
                 $this->_updateLog($prefix.$object['uid'], $bid, $stamp);
             }
-            foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::DELETED] as $bid => $object) {
+            foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::DELETED] as $bid => $object_uid) {
+                // Check if the object is really gone from the folder.
+                // Otherwise we just deleted a duplicated object or updated the original one.
+                // (An update results in an ADDED + DELETED folder action)
+                if ($this->data->objectIdExists($object_uid) == true)
+                    continue;
+
                 $this->history->log(
-                    $prefix.$object, array('action' => 'delete', 'bid' => $bid, 'stamp' => $stamp), true
+                    $prefix.$object_uid, array('action' => 'delete', 'bid' => $bid, 'stamp' => $stamp), true
                 );
             }
         } else {

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -109,9 +109,42 @@ implements Horde_Kolab_Storage_Data_Query_History
                 );
             }
         } else {
-            foreach ($this->data->getObjectToBackend() as $object => $bid) {
-                $this->_updateLog($prefix.$object, $bid);
-            }
+            // Full sync. Either our timestamp is too old
+            // or the IMAP uidvalidity changed
+            $this->_completeSynchronization($prefix, $is_reset);
+        }
+    }
+
+    /**
+     * Perform a complete synchronization.
+     * Also markes stale history entries as 'deleted'.
+     *
+     * @param string $prefix Horde_History prefix
+     * @param boolean $is_reset Flag to indicate if the UIDVALIDITY changed
+     *
+     * @return NULL
+     */
+    private function _completeSynchronization($prefix, $is_reset)
+    {
+        $seen_objects = array();
+        foreach ($this->data->getObjectToBackend() as $object => $bid) {
+            $full_id = $prefix.$object;
+            $this->_updateLog($full_id, $bid, $is_reset);
+            $seen_objects[$full_id] = true;
+        }
+
+        // cut of last ':'
+        $search_prefix = substr($prefix, 0, -1);
+
+        // clean up history database: Mark stale entries as deleted
+        $all_entries = $this->history->getByTimestamp('>', 0, array(), $search_prefix);
+        foreach ($all_entries as $full_id => $db_id) {
+            if (isset($seen_objects[$full_id]))
+                continue;
+
+            $this->history->log(
+                $full_id, array('action' => 'delete'), true
+            );
         }
     }
 
@@ -189,6 +222,7 @@ implements Horde_Kolab_Storage_Data_Query_History
     {
         $log = $this->history->getHistory($object);
         if (count($log) == 0) {
+            // New, unknown object
             $this->history->log(
                 $object, array('action' => 'add', 'bid' => $bid), true
             );

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -87,8 +87,9 @@ implements Horde_Kolab_Storage_Data_Query_History
         $prefix = $this->_constructHistoryPrefix();
         // Abort history update if we can't determine the prefix.
         // Otherwise we pollute the database with useless entries.
-        if (empty($prefix))
+        if (empty($prefix)) {
             return;
+        }
 
         // check if IMAP uidvalidity changed
         $is_reset = !empty($params['is_reset']);
@@ -101,8 +102,10 @@ implements Horde_Kolab_Storage_Data_Query_History
                 // Check if the object is really gone from the folder.
                 // Otherwise we just deleted a duplicated object or updated the original one.
                 // (An update results in an ADDED + DELETED folder action)
-                if ($this->data->objectIdExists($object_uid) == true)
+                if ($this->data->objectIdExists($object_uid) == true) {
+                    Horde::log('Skipping delete of still existing Kolab object ' . $object_uid, 'INFO');
                     continue;
+                }
 
                 $this->history->log(
                     $prefix.$object_uid, array('action' => 'delete', 'bid' => $bid), true
@@ -168,8 +171,10 @@ implements Horde_Kolab_Storage_Data_Query_History
             return $this->_prefix;
 
         $type = $this->_type2app($this->data->getType());
-        if (empty($type))
+        if (empty($type)) {
+            Horde::log('Unsupported app type: ' . $this->data->getType(), 'WARN');
             return '';
+        }
 
         // Determine share name
         $share_name = '';
@@ -183,8 +188,10 @@ implements Horde_Kolab_Storage_Data_Query_History
         $data = $query->getParameters($folder);
         if (isset($data['share_name']))
             $share_name = $data['share_name'];
-        else
+        else {
+            Horde::log("share_name not found. Can't compute history prefix for folder " . $folder, 'ERR');
             return '';
+        }
 
         $this->_prefix = $type.':'.$share_name.':';
 

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -74,7 +74,7 @@ implements Horde_Kolab_Storage_Data_Query_History
             }
             foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::DELETED] as $bid => $object) {
                 $this->history->log(
-                    $object, array('action' => 'delete', 'bid' => $bid, 'stamp' => $stamp)
+                    $object, array('action' => 'delete', 'bid' => $bid, 'stamp' => $stamp), true
                 );
             }
         } else {
@@ -99,7 +99,7 @@ implements Horde_Kolab_Storage_Data_Query_History
         $log = $this->history->getHistory($object);
         if (count($log) == 0) {
             $this->history->log(
-                $object, array('action' => 'add', 'bid' => $bid, 'stamp' => $stamp)
+                $object, array('action' => 'add', 'bid' => $bid, 'stamp' => $stamp), true
             );
         } else {
             $last = array('ts' => 0);
@@ -111,7 +111,7 @@ implements Horde_Kolab_Storage_Data_Query_History
             if (!isset($last['bid']) || $last['bid'] != $bid
                 || (isset($last['stamp']) && $last['stamp']->isReset($stamp))) {
                 $this->history->log(
-                    $object, array('action' => 'modify', 'bid' => $bid, 'stamp' => $stamp)
+                    $object, array('action' => 'modify', 'bid' => $bid, 'stamp' => $stamp), true
                 );
             }
         }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -52,6 +52,13 @@ implements Horde_Kolab_Storage_Data_Query_History
     protected $history;
 
     /**
+     * The precomputed history prefix
+     *
+     * @var string Cached history prefix string
+     */
+    private $_prefix;
+
+    /**
      * Constructor.
      *
      * @param Horde_Kolab_Storage_Data $data   The queriable data.
@@ -75,21 +82,87 @@ implements Horde_Kolab_Storage_Data_Query_History
      */
     public function synchronize($params = array())
     {
+        $prefix = $this->_constructHistoryPrefix();
+        // Abort history update if we can't determine the prefix.
+        // Otherwise we pollute the database with useless entries.
+        if (empty($prefix))
+            return;
+
         $stamp = $this->data->getStamp();
         if (isset($params['changes'])) {
             foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::ADDED] as $bid => $object) {
-                $this->_updateLog($object['uid'], $bid, $stamp);
+                $this->_updateLog($prefix.$object['uid'], $bid, $stamp);
             }
             foreach ($params['changes'][Horde_Kolab_Storage_Folder_Stamp::DELETED] as $bid => $object) {
                 $this->history->log(
-                    $object, array('action' => 'delete', 'bid' => $bid, 'stamp' => $stamp), true
+                    $prefix.$object, array('action' => 'delete', 'bid' => $bid, 'stamp' => $stamp), true
                 );
             }
         } else {
             foreach ($this->data->getObjectToBackend() as $object => $bid) {
-                $this->_updateLog($object, $bid, $stamp);
+                $this->_updateLog($prefix.$object, $bid, $stamp);
             }
         }
+    }
+
+    /**
+     * Construct prefix needed for Horde_History entries.
+     *
+     * Horde history entries are prefixed and filtered
+     * by application name and base64 encoded folder name.
+     *
+     * @return string Constructed prefix. Can be empty.
+     */
+    private function _constructHistoryPrefix()
+    {
+        // Check if we already know the full prefix
+        if (!empty($this->_prefix))
+            return $this->_prefix;
+
+        $type = $this->_type2app($this->data->getType());
+        if (empty($type))
+            return '';
+
+        // Determine share name
+        $share_name = '';
+        $folder = $this->data->getPath();
+
+        // TODO: Access global Kolab_Storage object if possible
+        // We probably have to extend the class structure for this.
+        $query = $this->factory->create()->getList()
+                ->getQuery(Horde_Kolab_Storage_List_Tools::QUERY_SHARE);
+
+        $data = $query->getParameters($folder);
+        if (isset($data['share_name']))
+            $share_name = $data['share_name'];
+        else
+            return '';
+
+        $this->_prefix = $type.':'.$share_name.':';
+
+        return $this->_prefix;
+    }
+
+    /**
+     * Map Kolab object type to horde application name.
+     *
+     * @param string $type Kolab object type
+     *
+     * @return string The horde application name. Empty string if unknown
+     */
+    private function _type2app($type)
+    {
+        $mapping = array(
+            'contact' => 'turba',
+            'event' => 'kronolith',
+            'note' => 'mnemo',
+            'task' => 'nag',
+        );
+
+        if (isset($mapping[$type]))
+            return $mapping[$type];
+
+        return '';
     }
 
     /**

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Base.php
@@ -188,8 +188,22 @@ implements Horde_Kolab_Storage_Data_Query_History
                 $action = $entry['action'];
                 if ($entry['ts'] > $last['ts'] && ($action == 'add' || $action == 'modify' || $action == 'delete')) {
                     $last = $entry;
+                } else if ($entry['ts'] == $last['ts'] && $action == 'delete') {
+                    // prefer 'delete' actions over other actions if the timestamp is the same.
+                    // see the logic below.
+                    $last = $entry;
                 }
             }
+
+            // If the last action for this object was 'delete', we issue an 'add'.
+            // Objects can vanish and re-appear using the same object uid.
+            // (a foreign client is sending an update over a slow link)
+            if ($last['action'] == 'delete') {
+                $this->history->log(
+                    $object, array('action' => 'add', 'bid' => $bid, 'stamp' => $stamp), true
+                );
+            }
+
             if (!isset($last['bid']) || $last['bid'] != $bid
                 || (isset($last['stamp']) && $last['stamp']->isReset($stamp))) {
                 $this->history->log(

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Cache.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Cache.php
@@ -53,7 +53,7 @@ extends Horde_Kolab_Storage_Data_Query_History_Base
         if (isset($params['current_sync'])) {
             $this->history->log(
                 __CLASS__ ,
-                array('action' => 'sync', 'ts' => $params['current_sync'])
+                array('action' => 'sync', 'ts' => $params['current_sync']), true
             );
         }
     }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Cache.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Cache.php
@@ -40,19 +40,22 @@ extends Horde_Kolab_Storage_Data_Query_History_Base
      */
     public function synchronize($params = array())
     {
+        $timestamp_key = 'Kolab_History_Sync:'.$this->data->getId();
+
         if (isset($params['last_sync']) &&
             ($params['last_sync'] === false ||
-             $params['last_sync'] !== $this->history->getActionTimestamp(__CLASS__ , 'sync'))) {
+             $params['last_sync'] !== $this->history->getActionTimestamp($timestamp_key, 'sync'))) {
             /**
              * Ignore current changeset and do a full synchronization as we are
              * out of sync
              */
             unset($params['changes']);
         }
+        // Sync. Base class takes care of UIDVALIDITY changes.
         parent::synchronize($params);
         if (isset($params['current_sync'])) {
             $this->history->log(
-                __CLASS__ ,
+                $timestamp_key,
                 array('action' => 'sync', 'ts' => $params['current_sync']), true
             );
         }

--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Cache.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Query/History/Cache.php
@@ -42,13 +42,27 @@ extends Horde_Kolab_Storage_Data_Query_History_Base
     {
         $timestamp_key = 'Kolab_History_Sync:'.$this->data->getId();
 
+        /**
+         * Check if we need to do a full synchronization. If our stored 'last_sync'
+         * timestamp is newer than the logged 'sync' action in the history database,
+         * the last history update aborted for some reason.
+         *
+         * If the 'sync' action from the history database is newer, it means
+         * our in-memory version of the data_cache was outdated
+         * and already updated by another process.
+         */
         if (isset($params['last_sync']) &&
             ($params['last_sync'] === false ||
-             $params['last_sync'] !== $this->history->getActionTimestamp($timestamp_key, 'sync'))) {
-            /**
-             * Ignore current changeset and do a full synchronization as we are
-             * out of sync
-             */
+             $params['last_sync'] > $this->history->getActionTimestamp($timestamp_key, 'sync')))
+        {
+            $folder_id = $this->data->getIdParameters();
+            unset($folder_id['type']);
+
+            Horde::log(sprintf('Resyncing Horde_History for Kolab: last_sync: %d, logged sync: %d, folder. %s',
+                           $params['last_sync'],
+                           $this->history->getActionTimestamp($timestamp_key, 'sync'),
+                           print_r($folder_id, true)), 'WARN');
+
             unset($params['changes']);
         }
         // Sync. Base class takes care of UIDVALIDITY changes.

--- a/framework/Kolab_Storage/test/Horde/Kolab/Storage/Unit/Data/Query/History/BaseTest.php
+++ b/framework/Kolab_Storage/test/Horde/Kolab/Storage/Unit/Data/Query/History/BaseTest.php
@@ -231,6 +231,43 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
+    public function testDuplicateRemoval()
+    {
+        $folder = $this->_getFolderBase(
+            array(
+                'user/test/History' => array(
+                    'a' => array(
+                        '/shared/vendor/kolab/folder-type' => 'note.default',
+                        '/shared/vendor/horde/share-params' => base64_encode(serialize(array('share_name' => 'internal_id')))
+                    ),
+                    'm' => array(
+                        1 => array('file' => __DIR__ . '/../../../../fixtures/note.eml'),
+                        2 => array('file' => __DIR__ . '/../../../../fixtures/note.eml'),
+                    ),
+                )
+            )
+        );
+
+        $data = $folder->getData('INBOX/History');
+        $data_query = $data->getQuery(Horde_Kolab_Storage_Data::QUERY_HISTORY);
+
+        $data_query->synchronize();
+        $data->delete('ABC1234');
+
+        // ensure no 'delete' was issued
+        $this->assertEquals(
+            0,
+            count($this->history->getByTimestamp('>', 0, array(
+                    array(
+                        'field' => 'action',
+                        'op' => '=',
+                        'value' => 'delete'
+                    )
+                ))
+            )
+        );
+    }
+
     private function _getData()
     {
         return $this->_getFolder()->getData('INBOX/History');

--- a/framework/Kolab_Storage/test/Horde/Kolab/Storage/Unit/Data/Query/History/BaseTest.php
+++ b/framework/Kolab_Storage/test/Horde/Kolab/Storage/Unit/Data/Query/History/BaseTest.php
@@ -7,6 +7,7 @@
  * @category Kolab
  * @package  Kolab_Storage
  * @author   Gunnar Wrobel <wrobel@pardus.de>
+ * @author   Thomas Jarosch <thomas.jarosch@intra2net.com>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @link     http://pear.horde.org/index.php?package=Kolab_Storage
  */
@@ -22,6 +23,7 @@
  * @category Kolab
  * @package  Kolab_Storage
  * @author   Gunnar Wrobel <wrobel@pardus.de>
+ * @author   Thomas Jarosch <thomas.jarosch@intra2net.com>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @link     http://pear.horde.org/index.php?package=Kolab_Storage
  */
@@ -35,7 +37,7 @@ extends Horde_Kolab_Storage_TestCase
             1,
             count(
                 $this->history->getHistory(
-                    '20080626155721.771268tms63o0rs4@devmail.example.com'
+                    'mnemo:internal_id:ABC1234'
                 )
             )
         );
@@ -46,8 +48,8 @@ extends Horde_Kolab_Storage_TestCase
         $this->_getDataQuery();
         $this->assertEquals(
             array(
-                '20080626155721.771268tms63o0rs4@devmail.example.com' => 1,
-                '20090731103253.11391snjudt9zgpw@webmail.example.com' => 2
+                'mnemo:internal_id:ABC1234' => 1,
+                'mnemo:internal_id:DEF5678' => 2
             ),
             $this->history->getByTimestamp(
                 '>',
@@ -65,11 +67,13 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testSingleAdd()
     {
+        // TODO: What is the purpose of this test exactly?
+        // It looks pretty identical to the test above.
         $this->_getDataQuery()->synchronize();
         $this->assertEquals(
             array(
-                '20080626155721.771268tms63o0rs4@devmail.example.com' => 1,
-                '20090731103253.11391snjudt9zgpw@webmail.example.com' => 2
+                'mnemo:internal_id:ABC1234' => 1,
+                'mnemo:internal_id:DEF5678' => 2
             ),
             $this->history->getByTimestamp(
                 '>',
@@ -88,11 +92,12 @@ extends Horde_Kolab_Storage_TestCase
     public function testModify()
     {
         $data = $this->_getData();
-        $o = $data->getObject('20090731103253.11391snjudt9zgpw@webmail.example.com');
+        $o = $data->getObject('DEF5678');
         $data->modify($o);
+
         $this->assertEquals(
             array(
-                '20090731103253.11391snjudt9zgpw@webmail.example.com' => 3
+                'mnemo:internal_id:DEF5678' => 3
             ),
             $this->history->getByTimestamp(
                 '>',
@@ -111,10 +116,11 @@ extends Horde_Kolab_Storage_TestCase
     public function testDelete()
     {
         $data = $this->_getData();
-        $data->delete('20090731103253.11391snjudt9zgpw@webmail.example.com');
+        $data->delete('ABC1234');
+
         $this->assertEquals(
             array(
-                '20090731103253.11391snjudt9zgpw@webmail.example.com' => 3
+                'mnemo:internal_id:ABC1234' => 3
             ),
             $this->history->getByTimestamp(
                 '>',
@@ -148,16 +154,32 @@ extends Horde_Kolab_Storage_TestCase
             $this->getDataAccount(
                 array(
                     'user/test/History' => array(
-                        't' => 'h-prefs.default',
+                        'a' => array(
+                            '/shared/vendor/kolab/folder-type' => 'note.default',
+                            '/shared/vendor/horde/share-params' => base64_encode(serialize(array('share_name' => 'internal_id')))
+                        ),
                         'm' => array(
-                            1 => array('file' => __DIR__ . '/../../../../fixtures/preferences.1'),
-                            2 => array('file' => __DIR__ . '/../../../../fixtures/preferences.2'),
+                            1 => array('file' => __DIR__ . '/../../../../fixtures/note.eml'),
+                            2 => array('file' => __DIR__ . '/../../../../fixtures/note2.eml'),
                         ),
                     )
                 )
             ),
             array(
                 'queryset' => array('data' => array('queryset' => 'horde')),
+                'queries' => array(
+                    'list' => array(
+                        Horde_Kolab_Storage_List_Tools::QUERY_BASE => array(
+                            'cache' => false
+                        ),
+                        Horde_Kolab_Storage_List_Tools::QUERY_ACL => array(
+                            'cache' => false
+                        ),
+                        Horde_Kolab_Storage_List_Tools::QUERY_SHARE => array(
+                            'cache' => false
+                        ),
+                    )
+                ),
                 'history' => $this->history
             )
         );

--- a/framework/Kolab_Storage/test/Horde/Kolab/Storage/fixtures/note2.eml
+++ b/framework/Kolab_Storage/test/Horde/Kolab/Storage/fixtures/note2.eml
@@ -1,0 +1,42 @@
+From: user
+To: user
+Date: Tue, 11 Sep 2012 09:06:04 +0200
+Subject: DEF5678
+User-Agent: Horde::Kolab::Storage v@version@
+MIME-Version: 1.0
+X-Kolab-Type: application/x-vnd.kolab.note
+Content-Type: multipart/mixed; name="Kolab Groupware Data";
+ boundary="=_23WLX7vgjhlQTuLb6j00EAA"
+Content-Disposition: attachment; filename="Kolab Groupware Data"
+
+This message is in MIME format.
+
+--=_23WLX7vgjhlQTuLb6j00EAA
+Content-Type: text/plain; name="Kolab Groupware Information"; charset=utf-8
+Content-Disposition: inline; filename="Kolab Groupware Information"
+
+This is a Kolab Groupware object. To view this object you will need an email
+client that understands the Kolab Groupware format. For a list of such email
+clients please visit http://www.kolab.org/content/kolab-clients
+--=_23WLX7vgjhlQTuLb6j00EAA
+Content-Type: application/x-vnd.kolab.note; name=kolab.xml
+Content-Disposition: inline; x-kolab-type=xml; filename=kolab.xml
+Content-Transfer-Encoding: quoted-printable
+
+<?xml version=3D"1.0" encoding=3D"UTF-8"?>
+<note version=3D"1.0">
+  <uid>DEF5678</uid>
+  <body></body>
+  <categories></categories>
+  <creation-date>2012-09-11T09:06:04Z</creation-date>
+  <last-modification-date>2012-09-11T07:06:04Z</last-modification-date>
+  <sensitivity>public</sensitivity>
+  <product-id>Horde_Kolab_Format_Xml-@version@ (api version: 2)</product-id=
+>
+  <summary>TEST2</summary>
+  <x-test>other client</x-test>
+  <background-color>#000000</background-color>
+  <foreground-color>#ffff00</foreground-color>
+</note>
+
+--=_23WLX7vgjhlQTuLb6j00EAA--


### PR DESCRIPTION
Hi,

this pull request adds full, synchronized Horde_History support to Kolab_Storage.
It also resolves a bunch of bugs, the corresponding bug number is noted in the commit.

All Kolab_Storage unit tests are up and running (and I introduced some new ones).

The new code is the basis for efficient ActiveSync support.

Cheers,
Thomas
