### PR TITLE
Add a 'status' action to detect if some migration scripts are pending

### DIFF
--- a/framework/Db/bin/horde-db-migrate-component
+++ b/framework/Db/bin/horde-db-migrate-component
@@ -32,7 +32,7 @@ foreach ($_SERVER['argv'] as $arg) {
     }
 }
 if (empty($args[1])) {
-    die("horde-db-migrate-component [--parameter=value ...] directory module [(up|down|version) [debug]]\n");
+    die("horde-db-migrate-component [--parameter=value ...] directory module [(up|down|version|status) [debug]]\n");
 }
 if (!isset($params['adapter'])) {
     die("The --adapter parameter is required. Other parameters may be required depending on the adapter.\n");
@@ -51,7 +51,9 @@ if (!empty($args[2])) {
     case 'down':
         $action = $args[2];
         break;
-
+    case 'status':
+        $action = $args[2];
+        break;
     default:
         $action = 'migrate';
         $targetVersion = $args[2];
@@ -95,7 +97,10 @@ try {
         echo "Migrating DB down.\n";
         $migrator->down();
         break;
-
+    case 'status':
+        echo 'Target schema version: ' . $migrator->getTargetVersion() . "\n";
+        exit( $migrator->getCurrentVersion() == $migrator->getTargetVersion() ? 0 : 1 );
+        break;
     case 'migrate':
         echo 'Migrating DB to schema version ' . $targetVersion . ".\n";
         $migrator->migrate($targetVersion);

--- a/horde/bin/horde-db-migrate
+++ b/horde/bin/horde-db-migrate
@@ -36,7 +36,7 @@ Horde_Registry::appInit('horde', array(
 // Parse command line arguments.
 $parser = new Horde_Argv_Parser(
     array(
-        'usage' => "%prog\n\t[--config=filename]\n\t[--debug]\n\t[(application|directory) [(up|down|version)]]",
+        'usage' => "%prog\n\t[--config=filename]\n\t[--debug]\n\t[(application|directory|ALL) [(up|down|version|status)]]",
         'optionList' => array(
             new Horde_Argv_Option(
                 '-c',
@@ -67,11 +67,15 @@ if (empty($args[0])) {
 } else {
     // Run a specific migration.
     $app = $args[0];
+
     if (($key = array_search($app, $migration->apps)) !== false) {
         $dir = $migration->dirs[$key];
     } elseif (($key = array_search($app, $migration->dirs)) !== false) {
         $dir = $app;
         $app = $migration->apps[$key];
+    } elseif ( $app == 'ALL' ) {
+        $apps = $migration->apps;
+        $dirs = $migration->dirs;
     } else {
         $cli->fatal(
             sprintf(
@@ -90,8 +94,10 @@ Supported directories:
             )
         );
     }
-    $dirs = array($dir);
-    $apps = array($app);
+    if ( $app != 'ALL' ) {
+        $dirs = array($dir);
+        $apps = array($app);
+    }
 }
 
 $action = 'up';
@@ -101,7 +107,9 @@ if (!empty($args[1])) {
     case 'down':
         $action = $args[1];
         break;
-
+    case 'status':
+        $action = $args[1];
+    break;
     default:
         $action = 'migrate';
         $targetVersion = $args[1];
@@ -128,11 +136,28 @@ case 'down':
 case 'migrate':
     $cli->message('Migrating DB to schema version ' . $targetVersion . '.');
     break;
+
+case 'status':
+    $cli->message('Check Migration DB status.');
+    break;
+
 }
 
 $logger = new Horde_Log_Logger(
     new Horde_Log_Handler_Stream(
         STDOUT, null, new Horde_Log_Formatter_Simple('%message%' . PHP_EOL)));
+
+$exit_code = 0;
+
+function sort_migrations($a, $b) {
+    // content must be run before nag or kronolith
+    if ($a == 'content' && $b == 'content') return 0;
+    if ($a == 'content' ) return -1;
+    if ($b == 'content' ) return 1;
+    return  strcmp(strtolower($a), strtolower($b));
+}
+
+usort($apps, 'sort_migrations');
 
 foreach ($apps as $app) {
     $migrator = $migration->getMigrator($app, $logger);
@@ -152,6 +177,15 @@ foreach ($apps as $app) {
         case 'migrate':
             $migrator->migrate($targetVersion);
             break;
+
+        case 'status':
+            if ( $migrator->getCurrentVersion() != $migrator->getTargetVersion() ) {
+                $exit_code = 1;
+            }
+            $cli->message("Target $app schema version: " . $migrator->getTargetVersion());
+            continue 2;
+            break;
+
         }
     } catch (Exception $e) {
         echo $e->getMessage() . "\n";
@@ -160,3 +194,4 @@ foreach ($apps as $app) {
 
     $cli->message("Ending $app schema version: " . $migrator->getCurrentVersion());
 }
+exit($exit_code);


### PR DESCRIPTION
- when running apps migration, order apps in order
  to have content before kronolith and nag
- add application 'ALL' to bin/horde-db-migrate to be able
  to run an action different than up ( as status ) for all
  apps
- add 'status' action to bin/horde-db-migrate to check
  if some migrations are missing
- add 'status' action to bin/horde-db-migrate-component
  to check if some migrations are missing
