### PR TITLE
horde-db-migrate and horde-db-migrate-component need to use the same tab...

### DIFF
--- a/framework/Db/bin/horde-db-migrate-component
+++ b/framework/Db/bin/horde-db-migrate-component
@@ -39,7 +39,8 @@ if (!isset($params['adapter'])) {
 }
 
 $dir = $args[0];
-$module = $args[1];
+// horde-db-migrate and horde-db-migrate-component need to use the same table name
+$module = strtolower($args[1]);
 if (!is_dir($dir)) {
     die("$dir is not a migration directory");
 }


### PR DESCRIPTION
when horde-db-migrate-component is used using an app name like Horde_Foo
then the schema version will be Horde_Foo_schema_info whereas when the components are upgraded from horde-db-migrate the schema table is lowercased: horde_foo_schema_info

that simple commit, make sure that same tables are going to be used when horde-db-migrate and horde-db-migrate-components are used
