### PR TITLE
Obly remove an index when defined.

### DIFF
--- a/framework/Db/lib/Horde/Db/Adapter/Base/Schema.php
+++ b/framework/Db/lib/Horde/Db/Adapter/Base/Schema.php
@@ -787,12 +787,19 @@ abstract class Horde_Db_Adapter_Base_Schema
     {
         $this->_clearTableCache($tableName);
 
-        $index = $this->indexName($tableName, $options);
+        $toremove = $this->indexName($tableName, $options);
         $sql = sprintf('DROP INDEX %s ON %s',
-                       $this->quoteColumnName($index),
+                       $this->quoteColumnName($toremove),
                        $this->quoteTableName($tableName));
+        // check if index exists before removing it
+        $indexes = $this->indexes($tableName);
+        foreach ( $indexes as $index ) {
+            if ( $index->getName() == $toremove ) {
+                return $this->execute($sql);
+            }
+        }
 
-        return $this->execute($sql);
+        return 0;
     }
 
     /**


### PR DESCRIPTION
When upgrading horde from an old version, migrations
can fail when trying to remove a non existing index.

That commit check if the index is defined before
removing it.
