### PR TITLE
add an extra flag exportData to be able to return the export content

### DIFF
--- a/turba/lib/Application.php
+++ b/turba/lib/Application.php
@@ -537,23 +537,29 @@ class Turba_Application extends Horde_Registry_Application
                 }
             }
 
+            $type;
+            $filename;
             switch ($vars->exportID) {
             case Horde_Data::EXPORT_CSV:
-                $injector->getInstance('Horde_Core_Factory_Data')->create('Csv', array('cleanup' => array($this, 'cleanupData')))->exportFile(_("contacts.csv"), $data, true);
-                exit;
+                $type = 'Csv';
+                $filename = "contacts.csv";
+                break;
 
             case Horde_Data::EXPORT_OUTLOOKCSV:
-                $injector->getInstance('Horde_Core_Factory_Data')->create('Outlookcsv', array('cleanup' => array($this, 'cleanupData')))->exportFile(_("contacts.csv"), $data, true, array_flip($this->getOutlookMapping()));
-                exit;
+                $type = 'Outlookcsv';
+                $filename = "contacts.csv";
+                break;
 
             case Horde_Data::EXPORT_TSV:
-                $injector->getInstance('Horde_Core_Factory_Data')->create('Tsv', array('cleanup' => array($this, 'cleanupData')))->exportFile(_("contacts.tsv"), $data, true);
-                exit;
+                $type = 'Tsv';
+                $filename = "contacts.tsv";
+                break;
 
             case Horde_Data::EXPORT_VCARD:
             case 'vcard30':
-                $injector->getInstance('Horde_Core_Factory_Data')->create('Vcard', array('cleanup' => array($this, 'cleanupData')))->exportFile(_("contacts.vcf"), $data, true);
-                exit;
+                $type = 'Vcard';
+                $filename = "contacts.vcf";
+                break;
 
             case 'ldif':
                 $ldif = new Turba_Data_Ldif(array(
@@ -564,6 +570,17 @@ class Turba_Application extends Horde_Registry_Application
                 $ldif->exportFile(_("contacts.ldif"), $data, true);
                 exit;
             }
+
+            if ( strlen($type) ) {
+                $imc = $injector->getInstance('Horde_Core_Factory_Data')->create($type, array('cleanup' => array($this, 'cleanupData')));
+                if ( $vars->exportData ) {
+                    return $imc->exportData($data, true);
+                } else {
+                    $imc->exportFile(_($filename), $data, true);
+                    exit;
+                }
+            }
+
 
             break;
         }


### PR DESCRIPTION
when calling the turba download method to export an address book
    $registry->callAppMethod('turba', 'download', .. )
we want to avoid the exit and be able to have access to the data
