### PR TITLE
Use the GetTempDir() method instead

### DIFF
--- a/framework/Util/lib/Horde/Util.php
+++ b/framework/Util/lib/Horde/Util.php
@@ -198,7 +198,7 @@ class Horde_Util
                                        $secure = false)
     {
         $tempDir = (empty($dir) || !is_dir($dir))
-            ? sys_get_temp_dir()
+            ? Horde::getTempDir()
             : $dir;
 
         $tempFile = tempnam($tempDir, $prefix);


### PR DESCRIPTION
sys_get_temp_dir might not be available, and we should use the
tempdir config consistently.
