### PR TITLE
use https image urls when horde runs in https environment

### DIFF
--- a/horde/services/twitter/index.php
+++ b/horde/services/twitter/index.php
@@ -188,7 +188,7 @@ case 'getPage':
 
         /* These are all referencing the *original* tweet */
         $view->profileLink = Horde::externalUrl('http://twitter.com/' . htmlspecialchars($tweetObj->user->screen_name), true);
-        $view->profileImg = $_SERVER['HTTPS'] ? $tweetObj->user->profile_image_url_https : $tweetObj->user->profile_image_url;
+        $view->profileImg = $GLOBALS['browser']->usingSSLConnection() ? $tweetObj->user->profile_image_url_https : $tweetObj->user->profile_image_url;
         $view->authorName = '@' . htmlspecialchars($tweetObj->user->screen_name);
         $view->authorFullname = htmlspecialchars($tweetObj->user->name);
         $view->createdAt = $tweetObj->created_at;


### PR DESCRIPTION
this fixes bug #9983 from bugs.horde.org

now that the response of the api includes also an https url this should be used for https sites
