### PR TITLE
Skip Horde_Text_Filter_JavascriptMinify_JsMin if not found

### DIFF
--- a/framework/Text_Filter/lib/Horde/Text/Filter/JavascriptMinify.php
+++ b/framework/Text_Filter/lib/Horde/Text/Filter/JavascriptMinify.php
@@ -48,6 +48,9 @@ class Horde_Text_Filter_JavascriptMinify extends Horde_Text_Filter_Base
         }
 
         /* Use PHP-based minifier. */
+        if (!class_exists('Horde_Text_Filter_JavascriptMinify_JsMin')) {
+            return $text;
+        }
         $jsmin = new Horde_Text_Filter_JavascriptMinify_JsMin($text);
         try {
             return $jsmin->minify();


### PR DESCRIPTION
As this class is removed in Debian because of being non-free.

This prevent PHP fatal
