### PR TITLE
missing $text parameter in signature

### DIFF
--- a/framework/Text_Filter/lib/Horde/Text/Filter/JavascriptMinify.php
+++ b/framework/Text_Filter/lib/Horde/Text/Filter/JavascriptMinify.php
@@ -68,7 +68,7 @@ class Horde_Text_Filter_JavascriptMinify extends Horde_Text_Filter_Base
      *
      * @return string  The modified text.
      */
-    protected function _runCompressor($jar, $args = '')
+    protected function _runCompressor($text, $jar, $args = '')
     {
         if (!is_executable($this->_params['java']) ||
             !file_exists($jar)) {


### PR DESCRIPTION
added the $text parameter to the signature to get the closure compiler and yui compressor working. without this parameter an empty file is returned.
