### PR TITLE
invalid connection option "query_lookup"

### DIFF
--- a/passwd/lib/Factory/Driver.php
+++ b/passwd/lib/Factory/Driver.php
@@ -119,7 +119,8 @@ class Passwd_Factory_Driver extends Horde_Core_Factory_Base
                             $params = $backend['params'];
                             unset($params['table'], $params['user_col'],
                                   $params['pass_col'], $params['encryption'],
-                                  $params['show_encryption']);
+                                  $params['show_encryption'],
+                                  $params['query_lookup'], $params['query_modify']);
                             $backend['params']['db'] = $this->_injector
                                 ->getInstance('Horde_Core_Factory_Db')
                                 ->create('passwd', $params);


### PR DESCRIPTION
this change fixes to error when using pgsql driver.

Could not instantiate PDO with DSN "pgsql:query_lookup=SELECT password FROM mailbox WHERE username = %u and active = 1;query_modify=UPDATE mailbox SET password = %e WHERE username = %u;host=localhost;dbname=postfix".  PDOException: SQLSTATE[08006] [7] invalid connection option "query_lookup"
