### PR TITLE
Don't use $_SERVER['REDIRECT_URL'] (Ticket 11759)

### DIFF
--- a/framework/Core/lib/Horde/Core/Factory/Request.php
+++ b/framework/Core/lib/Horde/Core/Factory/Request.php
@@ -8,7 +8,7 @@ class Horde_Core_Factory_Request extends Horde_Core_Factory_Injector
     public function create(Horde_Injector $injector)
     {
         $request = new Horde_Controller_Request_Http();
-        $request->setPath(isset($_SERVER['REDIRECT_URL']) ? $_SERVER['REDIRECT_URL'] : $_SERVER['REQUEST_URI']);
+        $request->setPath($_SERVER['REQUEST_URI']);
         return $request;
     }
 }


### PR DESCRIPTION
As described in http://bugs.horde.org/ticket/11759, REDIRECT_URL serves no purpose and breaks Horde installations on anything which is not Apache+mod_php - this includes nginx, php on fastcgi and php-fpm.
If the files framework/Controller/lib/Horde/Controller/Request/Mock.php and /MockRequestTest.php need to be updated, too, let me know.