### PR TITLE
Fix invalid foreach statement (Bug #12992)

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
@@ -2724,7 +2724,7 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
 
             case Horde_Imap_Client::FETCH_BODYPARTSIZE:
                 if ($this->queryCapability('BINARY')) {
-                    foreach ($c_val as $val) {
+                    foreach ($c_val as $key => $val) {
                         $fetch->add('BINARY.SIZE[' . $key . ']');
                     }
                 }


### PR DESCRIPTION
The commit 59d11b153a16de754edbcffb426c52324e4c17f3 introduces a badly declared foreach loop to process BODYPARTSIZE for binary parts. This cause a undefined index 'key' PHP error.
