### PR TITLE
fixed checking whether array key is set

### DIFF
--- a/framework/Db/lib/Horde/Db/Adapter/Base/Schema.php
+++ b/framework/Db/lib/Horde/Db/Adapter/Base/Schema.php
@@ -900,7 +900,7 @@ abstract class Horde_Db_Adapter_Base_Schema
 
         $sql = is_array($native) ? $native['name'] : $native;
         if ($type == 'decimal' ||
-            isset($native['precision']) || isset($native['scale']) ||
+            is_array($native) && (isset($native['precision']) || isset($native['scale'])) ||
             isset($precision) || isset($scale)) {
             $nativePrec  = isset($native['precision']) ? $native['precision'] : null;
             $nativeScale = isset($native['scale'])     ? $native['scale']     : null;


### PR DESCRIPTION
We need to check whether $native is an array before asking for key's existance. If $native is string, isset($native['...']) will always return true, because it's evaluated as $native[0] which is the first character of the string.
