### PR TITLE
Add device for Horde_ActiveSync_Message_Contact

### DIFF
--- a/framework/Core/lib/Horde/Core/ActiveSync/Driver.php
+++ b/framework/Core/lib/Horde/Core/ActiveSync/Driver.php
@@ -1200,7 +1200,8 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                     'protocolversion' => $this->_version,
                     'truncation' => $collection['truncation'],
                     'bodyprefs' => $this->addDefaultBodyPrefTruncation($collection['bodyprefs']),
-                    'mimesupport' => $collection['mimesupport']));
+                    'mimesupport' => $collection['mimesupport'],
+                    'device' => $this->_device));
             } catch (Horde_Exception $e) {
                 $this->_logger->err($e->getMessage());
                 $this->_endBuffer();

--- a/turba/lib/Driver.php
+++ b/turba/lib/Driver.php
@@ -2518,8 +2518,9 @@ class Turba_Driver implements Countable
 
         $message = new Horde_ActiveSync_Message_Contact(array(
             'logger' => $injector->getInstance('Horde_Log_Logger'),
-            'protocolversion' => $options['protocolversion'])
-        );
+            'protocolversion' => $options['protocolversion'],
+            'device' => $options['device']
+        ));
         $hash = $object->getAttributes();
         if (!isset($hash['lastname']) && isset($hash['name'])) {
             $this->_guessName($hash);


### PR DESCRIPTION
Horde_ActiveSync_Message_Contact is checking if _device is available. If it is, the device-specific date format should be used.
This was code was never called, as the _device variable is never set. This should fix it.

Now the device specific date format is used also, which fixes the birthdates of contacts now. Before the dates were shifted by one day.
When editing the birthdate of a contact in the addressbook (for example 04.03.1991), before the log showed: POOMCONTACTS:Birthday1991-03-03T23:00:00.000Z/POOMCONTACTS:Birthday, now it shows the correct device specific date format: POOMCONTACTS:Birthday1991-03-04T12:00:00.000Z/POOMCONTACTS:Birthday
