### PR TITLE
need to call toString()

### DIFF
--- a/framework/Http/lib/Horde/Http/Response/Peclhttp2.php
+++ b/framework/Http/lib/Horde/Http/Response/Peclhttp2.php
@@ -49,6 +49,6 @@ class Horde_Http_Response_Peclhttp2 extends Horde_Http_Response_Base
 
     public function getBody()
     {
-        return $this->_response->getBody();
+        return $this->_response->getBody()->toString();
     }
 }


### PR DESCRIPTION
implicit call to __toString doesn't work in all cases (weather service is one of that)
