### PR TITLE
Fixed string splitting with unicode characters in inline renderer

### DIFF
--- a/framework/Text_Diff/lib/Horde/Text/Diff/Renderer/Inline.php
+++ b/framework/Text_Diff/lib/Horde/Text/Diff/Renderer/Inline.php
@@ -146,8 +146,8 @@ class Horde_Text_Diff_Renderer_Inline extends Horde_Text_Diff_Renderer
 
         if ($this->_split_characters) {
             $diff = new Horde_Text_Diff('native',
-                                  array(preg_split('//', $text1),
-                                        preg_split('//', $text2)));
+                                  array(preg_split('//u', $text1),
+                                        preg_split('//u', $text2)));
         } else {
             /* We want to split on word boundaries, but we need to preserve
              * whitespace as well. Therefore we split on words, but include


### PR DESCRIPTION
When the renderer gets a string with utf-8 characters, `preg_split`'s pattern mus have the `u` (unicode) flag, or it will fail to split the string properly.
