### PR TITLE
Fix Event Url and Url Display

### DIFF
--- a/kronolith/js/kronolith.js
+++ b/kronolith/js/kronolith.js
@@ -5817,7 +5817,15 @@ KronolithCore = {
             $('kronolithEventUrlDisplay').show();
             $('kronolithEventUrl').hide();
         }
-        $('kronolithEventUrl').setValue(ev.u);
+        else {
+            $('kronolithEventUrlDisplay').hide();
+            $('kronolithEventUrl').show();
+        }
+
+        if (ev.u) {
+            $('kronolithEventUrl').setValue(ev.u);
+        }
+
         $('kronolithEventAllday').setValue(ev.al);
 
         if (ev.r && ev.rsd && ev.red) {


### PR DESCRIPTION
Hello,

i noticed that if i edit one event with url set, it shows the "new" event url display, 

if i edit another event without url, the form continues to show the url display from the other event,

if i try to create a new event, the same problem occurs.

and as a bonus i do not update the event url to empty if open event doesn't has url set,
to uniformize with a new event that shows 'http://' as default value.

Thanks in advance
