### PR TITLE
Fixing locale directory for Packages installed with Composer

### DIFF
--- a/framework/Exception/lib/Horde/Exception/Translation.php
+++ b/framework/Exception/lib/Horde/Exception/Translation.php
@@ -27,7 +27,7 @@ class Horde_Exception_Translation extends Horde_Translation
     static public function t($message)
     {
         self::$_domain = 'Horde_Exception';
-        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../locale' : '@data_dir@/Horde_Exception/locale';
+        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../locale' : '@data_dir@/locale';
         return parent::t($message);
     }
 
@@ -44,7 +44,7 @@ class Horde_Exception_Translation extends Horde_Translation
     static public function ngettext($singular, $plural, $number)
     {
         self::$_domain = 'Horde_Exception';
-        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../locale' : '@data_dir@/Horde_Exception/locale';
+        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../locale' : '@data_dir@/locale';
         return parent::ngettext($singular, $plural, $number);
     }
 }

--- a/framework/Imap_Client/lib/Horde/Imap/Client/Translation.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Translation.php
@@ -33,7 +33,7 @@ class Horde_Imap_Client_Translation extends Horde_Translation
     static public function t($message)
     {
         self::$_domain = 'Horde_Imap_Client';
-        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/Horde_Imap_Client/locale';
+        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/locale';
         return parent::t($message);
     }
 
@@ -50,7 +50,7 @@ class Horde_Imap_Client_Translation extends Horde_Translation
     static public function ngettext($singular, $plural, $number)
     {
         self::$_domain = 'Horde_Imap_Client';
-        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/Horde_Imap_Client/locale';
+        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/locale';
         return parent::ngettext($singular, $plural, $number);
     }
 }


### PR DESCRIPTION
I've installed `Horde_Imap_Client` package with Composer, but it fails to load the translation files.

Those packages results in having the data/locale directory at `/path/to/pear-pear.horde.org/Horde_Package/data/locale` while translations are trying to access `/path/to/pear-pear.horde.org/Horde_Package/data/Horde_Package/locale`

On a related note: it would be great if `@data_dir@` is not "hardcoded" as in not having the absolute path on it but rather use PHP functions like [dirname](php.net/dirname) to define it.

It is necessary when you have a build server, for example. At my daily job releases are prepared by a build server, which effectively does a `composer install`, but it does not quite work because the paths are different from the target server. :/

Composer code installing it: https://github.com/composer/composer/commit/bc2d30492afbcfcb88001e13229fc0f9f29022e2
