### PR TITLE
Fixed problems with locale directories

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Translation.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Translation.php
@@ -33,7 +33,7 @@ class Horde_Imap_Client_Translation extends Horde_Translation
     static public function t($message)
     {
         self::$_domain = 'Horde_Imap_Client';
-        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/Horde_Imap_Client/locale';
+        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/locale';
         return parent::t($message);
     }
 
@@ -50,7 +50,7 @@ class Horde_Imap_Client_Translation extends Horde_Translation
     static public function ngettext($singular, $plural, $number)
     {
         self::$_domain = 'Horde_Imap_Client';
-        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/Horde_Imap_Client/locale';
+        self::$_directory = '@data_dir@' == '@'.'data_dir'.'@' ? __DIR__ . '/../../../../locale' : '@data_dir@/locale';
         return parent::ngettext($singular, $plural, $number);
     }
 }


### PR DESCRIPTION
I don't know what's happening, and i'm not sure this fix is appropriate (since if it was really a bug it should have been caught much earlier).

I'm using the library, and the application is running inside Vagrant. Now I get this exception:

```
 /vagrant/vendor/pear-pear.horde.org/Horde_Imap_Client/data/Horde_Imap_Client/locale is not a directory
```

The translations are in _/vagrant/vendor/pear-pear.horde.org/Horde_Imap_Client/data/locale_, so that's why I tried to fix the path by removing `Horde_Imap_Client`.
