### PR TITLE
Fix calendar dropdown positioning if page is scrolled.

### DIFF
--- a/framework/Core/js/calendar.js
+++ b/framework/Core/js/calendar.js
@@ -184,10 +184,10 @@ var Horde_Calendar =
                 div.setStyle({ left: p.left + 'px' });
             }
 
-            if (p.top + div.offsetHeight > vp.height) {
+            if (p.top + div.offsetHeight > vp.height + window.pageYOffset) {
                 div.setStyle({ top: (window.pageYOffset + vp.height - 10 - div.offsetHeight) + 'px' });
             } else {
-                div.setStyle({ top: (window.pageYOffset + p.top) + 'px' });
+                div.setStyle({ top: p.top + 'px' });
             }
         }
 


### PR DESCRIPTION
With this patch the calendar dropdown will be correctly positioned if the page is scrolled to the bottom. Otherwise the calendar would've opened relative to the page beginning at the "correct" position which is - if scrolled - incorrect.
