### PR TITLE
Give possibility to set new due date through API

### DIFF
--- a/whups/lib/Api.php
+++ b/whups/lib/Api.php
@@ -246,6 +246,9 @@ class Whups_Api extends Horde_Registry_Api
         if (!empty($info['newcomment'])) {
             $ticket->change('comment', $info['newcomment']);
         }
+        if (!empty($info['due'])) {
+            $ticket->change('due', $info['due']);
+        }
 
         // Update attributes.
         $whups_driver->setAttributes($info, $ticket);


### PR DESCRIPTION
This patch allows the user to set a due-date through Whups API when updating a ticket.
