### PR TITLE
Invalidate Zend OPcache to ensure saved version used

### DIFF
--- a/framework/Core/lib/Horde/Config.php
+++ b/framework/Core/lib/Horde/Config.php
@@ -301,10 +301,10 @@ class Horde_Config
             fwrite($fp, $php);
             fclose($fp);
             $GLOBALS['registry']->rebuild();
-            $GLOBALS['notification']->push(sprintf(Horde_Core_Translation::t("Successfully wrote %s"), Horde_Util::realPath($configFile)), 'horde.success');
+            $GLOBALS['notification']->push(sprintf(Horde_Core_Translation::t("Successfully wrote %s"), $rp = Horde_Util::realPath($configFile)), 'horde.success');
             if (function_exists('opcache_invalidate')) {
                 /* Invalidate Zend OPcache to ensure saved version used */
-                opcache_invalidate($configFile, true);
+                opcache_invalidate($rp, true);
             }
             return true;
         }

--- a/framework/Core/lib/Horde/Config.php
+++ b/framework/Core/lib/Horde/Config.php
@@ -302,6 +302,10 @@ class Horde_Config
             fclose($fp);
             $GLOBALS['registry']->rebuild();
             $GLOBALS['notification']->push(sprintf(Horde_Core_Translation::t("Successfully wrote %s"), Horde_Util::realPath($configFile)), 'horde.success');
+            if (function_exists('opcache_invalidate')) {
+                /* Invalidate Zend OPcache to ensure saved version used */
+                opcache_invalidate($configFile, true);
+            }
             return true;
         }
 


### PR DESCRIPTION
When using an opcode cache, configuration files are cached.

So, after a configuration file is updated, its old content will be served by cached until invalidated, or checked.

With Zend Opcache, default check delay is 2"

```
opcache.revalidate_freq=2
```

And, it is common to have a greater value on production env.

This PR fix this (only for opcache, other opcode caches such as XCache or deprecated APC are not handled)
