### PR TITLE
it is possible that $this->_cache is empty

### DIFF
--- a/imp/lib/Factory/MailboxList.php
+++ b/imp/lib/Factory/MailboxList.php
@@ -93,8 +93,10 @@ implements Horde_Shutdown_Task
      */
     public function expireAll()
     {
-        foreach ($this->_cache as $val) {
-            $val->clear();
+        if (!empty($this->_cache)) {
+            foreach ($this->_cache as $val) {
+                $val->clear();
+            }
         }
         $this->_instances = array();
     }


### PR DESCRIPTION
Fixing errors like:
WARN: HORDE [imp] PHP ERROR: Invalid argument supplied for foreach() [pid 123 on line 97 of "/var/www/vhosts/horde-dev.immerda.ch/www/imp/lib/Factory/MailboxList.php"]
