### PR TITLE
fix #13590 - allow non-ASCII characters for passwords during LOGIN

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
@@ -726,10 +726,13 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
         case 'LOGIN':
             /* See, e.g., RFC 6855 [5] - LOGIN command does not support
              * non-ASCII characters. If we reach this point, treat as an
-             * authentication failure. */
+             * authentication failure.
+             * #13590 -> imapproxy only supports LOGIN, but most imap
+             * server support non-ASCII characters using LOGIN. Hence,
+             * we allow non-ASCII characters for the password. */
             try {
                 $username = new Horde_Imap_Client_Data_Format_Astring($username);
-                $password = new Horde_Imap_Client_Data_Format_Astring($password);
+                $password = new Horde_Imap_Client_Data_Format_Astring_Nonascii($password);
             } catch (Horde_Imap_Client_Data_Format_Exception $e) {
                 throw new Horde_Imap_Client_Exception(
                     Horde_Imap_Client_Translation::r("Authentication failed."),


### PR DESCRIPTION
Without that there is no way, that horde can be used together with
imapproxy, because it only supports the LOGIN mechanism and if we
don't support non-ASCII characters within a passwords, lots of
passwords won't be accepted.
Most imap servers (e.g. accept non-ASCII characters during LOGIN,
which makes this change safe.
