### PR TITLE
Fixing composer.json syntax errors

### DIFF
--- a/framework/Autoloader_Cache/composer.json
+++ b/framework/Autoloader_Cache/composer.json
@@ -9,7 +9,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Browser/composer.json
+++ b/framework/Browser/composer.json
@@ -9,7 +9,7 @@
             "name": "Chuck Hagenbuch",
             "email": "chuck@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Compress/composer.json
+++ b/framework/Compress/composer.json
@@ -19,7 +19,7 @@
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael J Rubinsky",
             "email": "mrubinsk@horde.org",

--- a/framework/Core/composer.json
+++ b/framework/Core/composer.json
@@ -14,7 +14,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Data/composer.json
+++ b/framework/Data/composer.json
@@ -9,7 +9,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Chuck Hagenbuch",
             "email": "chuck@horde.org",

--- a/framework/Exception/composer.json
+++ b/framework/Exception/composer.json
@@ -14,7 +14,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Icalendar/composer.json
+++ b/framework/Icalendar/composer.json
@@ -14,7 +14,7 @@
             "name": "Chuck Hagenbuch",
             "email": "chuck@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael J Rubinsky",
             "email": "mrubinsk@horde.org",

--- a/framework/Kolab_Resource/composer.json
+++ b/framework/Kolab_Resource/composer.json
@@ -24,7 +24,7 @@
         "pear-pear.php.net/HTTP_Request": "*",
         "pear-pear.horde.org/Horde_Icalendar": ">=2.0.0,<=3.0.0alpha1",
         "pear-pear.horde.org/Horde_Mime": ">=2.0.0,<=3.0.0alpha1",
-        "pear-pear.horde.org/Horde_Translation": ">=2.2.0@stable,<=3.0.0alpha1@stable"
+        "pear-pear.horde.org/Horde_Translation": ">=2.2.0@stable,<=3.0.0alpha1@stable",
         "pear-pear.horde.org/Horde_Util": ">=2.0.0,<=3.0.0alpha1",
         "pear-pear.horde.org/Horde_Kolab_Server": ">=2.0.0,<=3.0.0alpha1",
         "pear-pear.horde.org/Horde_Kolab_Storage": ">=2.0.0,<=3.0.0alpha1"

--- a/framework/Rpc/composer.json
+++ b/framework/Rpc/composer.json
@@ -14,7 +14,7 @@
             "name": "Chuck Hagenbuch",
             "email": "chuck@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael J Rubinsky",
             "email": "mrubinsk@horde.org",

--- a/framework/Serialize/composer.json
+++ b/framework/Serialize/composer.json
@@ -14,7 +14,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Service_Scribd/composer.json
+++ b/framework/Service_Scribd/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.3.0",
         "pear-pear.horde.org/Horde_Http": ">=2.0.0,<=3.0.0alpha1",
-        "pear-pear.horde.org/Horde_Translation": ">=2.2.0@stable,<=3.0.0alpha1@stable"
+        "pear-pear.horde.org/Horde_Translation": ">=2.2.0@stable,<=3.0.0alpha1@stable",
         "pear-pear.horde.org/Horde_Xml_Element": ">=2.0.0,<=3.0.0alpha1"
     }
 }

--- a/framework/Stringprep/composer.json
+++ b/framework/Stringprep/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "horde/horde-stringprep",
-    "description": "PHP implementation of RFC 3454 - Preparation of Internationalized Strings ("stringprep").",
+    "description": "PHP implementation of RFC 3454 - Preparation of Internationalized Strings ('stringprep').",
     "type": "library",
     "homepage": "http://pear.horde.org",
     "license": "LGPL-3.0",

--- a/framework/Support/composer.json
+++ b/framework/Support/composer.json
@@ -14,7 +14,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Text_Filter/composer.json
+++ b/framework/Text_Filter/composer.json
@@ -14,7 +14,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Tree/composer.json
+++ b/framework/Tree/composer.json
@@ -14,7 +14,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/framework/Util/composer.json
+++ b/framework/Util/composer.json
@@ -14,7 +14,7 @@
             "name": "Jan Schneider",
             "email": "jan@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",

--- a/turba/composer.json
+++ b/turba/composer.json
@@ -19,7 +19,7 @@
             "name": "Chuck Hagenbuch",
             "email": "chuck@horde.org",
             "role": "lead"
-        }
+        },
         {
             "name": "Michael Slusarz",
             "email": "slusarz@horde.org",


### PR DESCRIPTION
This fixes syntax errors for composer.json files.

Apart from this changes, another thing that would need to fixed are the package names on `require` as they need to match the name defined in `name`.
Take `framework/Exception/composer.json` for example. The package name is defined as `horde/horde-exception` yet packages that depends on it requires it as `pear-pear.horde.org/Horde_Exception`.

I want to tackle this as well. But what should be the convention for the package names?
1. `horde/horde-exception`
2. or `horde/Horde_Exception`
3. or just `horde/Exception`
