### PR TITLE
fix compat with PHP 5.3

### DIFF
--- a/framework/Db/lib/Horde/Db/Adapter/Base.php
+++ b/framework/Db/lib/Horde/Db/Adapter/Base.php
@@ -620,20 +620,14 @@ abstract class Horde_Db_Adapter_Base implements Horde_Db_Adapter
         if (is_array($where)) {
             $where = $this->_replaceParameters($where[0], $where[1]);
         }
-
+        $fnames = array();
+        foreach($fields as $field => $value) {
+            $fnames[] = $this->quoteColumnName($field) . ' = ?';
+        }
         $query = sprintf(
             'UPDATE %s SET %s%s',
             $this->quoteTableName($table),
-            implode(
-                ', ',
-                array_map(
-                    function($field)
-                    {
-                        return $this->quoteColumnName($field) . ' = ?';
-                    },
-                    array_keys($fields)
-                )
-            ),
+            implode(', ', $fnames),
             strlen($where) ? ' WHERE ' . $where : ''
         );
         return $this->update($query, $fields);


### PR DESCRIPTION
When running test suite against PHP 5.3.3 (RHEL-6)

```
  PHP Fatal error:  Using $this when not in object context in /builddir/build/BUILD/php-horde-Horde-Db-2.2.0/Horde_Db-2.2.0/lib/Horde/Db/Adapter/Base.php on line 632
```

I think older PHP doesn't allow to use this inside an anonymous function.

This simple fix restore PHP 5.3 compatibility (supported, according to package.xml min version)
