### PR TITLE
Fixing class name to match file name

### DIFF
--- a/framework/Mime/lib/Horde/Mime/Headers/MessageId.php
+++ b/framework/Mime/lib/Horde/Mime/Headers/MessageId.php
@@ -21,7 +21,7 @@
  * @package   Mime
  * @since     2.5.0
  */
-class Horde_Mime_Headers_Messageid
+class Horde_Mime_Headers_MessageId
 extends Horde_Mime_Headers_Identification
 {
     /**


### PR DESCRIPTION
```
Fatal error: Class 'Horde_Mime_Headers_MessageId' not found in ....../pear-pear.horde.org/Horde_Mime/Horde/Mime/Headers.php on line 275
```
