### PR TITLE
Fix GPG Publkey import when also provided by Hook

### DIFF
--- a/imp/lib/Crypt/Pgp.php
+++ b/imp/lib/Crypt/Pgp.php
@@ -160,7 +160,7 @@ class IMP_Crypt_Pgp extends Horde_Crypt_Pgp
              * address book and remove the id from the key_info for a correct
              * output. */
             try {
-                $result = $this->getPublicKey($sig['email'], array('nocache' => true, 'noserver' => true));
+                $result = $this->getPublicKey($sig['email'], array('nocache' => true, 'noserver' => true, 'nohooks' => true));
                 if (!empty($result)) {
                     unset($key_info['signature'][$id]);
                     continue;
@@ -213,16 +213,18 @@ class IMP_Crypt_Pgp extends Horde_Crypt_Pgp
             }
         }
 
-        try {
-            $key = $injector->getInstance('Horde_Core_Hooks')->callHook(
-                'pgp_key',
-                'imp',
-                array($address, $keyid)
-            );
-            if ($key) {
-                return $key;
-            }
-        } catch (Horde_Exception_HookNotSet $e) {}
+        if (empty($options['nohooks'])) {
+            try {
+                $key = $injector->getInstance('Horde_Core_Hooks')->callHook(
+                    'pgp_key',
+                    'imp',
+                    array($address, $keyid)
+                );
+                if ($key) {
+                    return $key;
+                }
+            } catch (Horde_Exception_HookNotSet $e) {}
+        }
 
         /* Try retrieving by e-mail only first. */
         $result = null;


### PR DESCRIPTION
If a GPG Publickey happens to be provided by a gpg_key Hook in IMP it
was not possible for a user to import said key into his keyring.

This Patch skips gpg_key hook when getPublicKey is called to determine if
a user already has the PublicKey in his keyring.
