### PR TITLE
add option to specify the redis database index to connect to

### DIFF
--- a/framework/Core/lib/Horde/Core/Factory/HashTable.php
+++ b/framework/Core/lib/Horde/Core/Factory/HashTable.php
@@ -60,6 +60,7 @@ class Horde_Core_Factory_HashTable extends Horde_Core_Factory_Injector
             $params = array_merge(array(
                 'hostspec' => array(),
                 'password' => null,
+                'database' => null,
                 'port' => '',
                 'protocol' => 'tcp',
             ), $params);
@@ -67,7 +68,8 @@ class Horde_Core_Factory_HashTable extends Horde_Core_Factory_Injector
 
             $common = array_filter(array(
                 'password' => strlen($params['password']) ? $params['password'] : null,
-                'persistent' => !empty($params['persistent'])
+                'persistent' => !empty($params['persistent']),
+                'database' => !empty($params['database']) ? $params['database'] : null
             ));
 
             switch ($params['protocol']) {

--- a/horde/config/conf.xml
+++ b/horde/config/conf.xml
@@ -2115,6 +2115,8 @@
       </configswitch>
       <configstring name="password" required="false" desc="Password to
       authenticate to the Redis server with."/>
+      <configinteger name="database" required="false" desc="Database
+      index to select when connected to Redis server."/>
       <configboolean name="persistent" required="false" desc="Enable
       persistent connections to Redis server(s)?">false</configboolean>
      </configsection>

--- a/horde/config/conf.xml
+++ b/horde/config/conf.xml
@@ -2115,7 +2115,7 @@
       </configswitch>
       <configstring name="password" required="false" desc="Password to
       authenticate to the Redis server with."/>
-      <configinteger name="database" required="false" desc="Database
+      <configstring name="database" required="false" desc="Database
       index to select when connected to Redis server."/>
       <configboolean name="persistent" required="false" desc="Enable
       persistent connections to Redis server(s)?">false</configboolean>


### PR DESCRIPTION
with this change it is possible to change the used database so that no longer all keys go to the default database

see https://github.com/nrk/predis/wiki/Quick-tour#parameters