### PR TITLE
Ansel: Remove unneeded dependency on opencv

### DIFF
--- a/ansel/package.xml
+++ b/ansel/package.xml
@@ -801,9 +801,6 @@
     <name>libpuzzle</name>
    </extension>
    <extension>
-    <name>opencv</name>
-   </extension>
-   <extension>
     <name>php-facedetect</name>
    </extension>
   </optional>


### PR DESCRIPTION
According to 2.0alpha1 changelog which says: "Remove support for no longer available openCV extension."