### PR TITLE
Fix for ActiveSync without e-mail on Android 5.

### DIFF
--- a/imp/js/base.js
+++ b/imp/js/base.js
@@ -708,7 +708,7 @@ var ImpBase = {
                     }
                     $('search_label').update(tmp.escapeHTML());
                 }
-                [ $('search_edit') ].invoke(this.search || this.viewport.getMetaData('noedit') ? 'hide' : 'show');
+                [ $('search_edit') ].compact().invoke(this.viewport.getMetaData('noedit') ? 'hide' : 'show');
                 this.showSearchbar(true);
             } else {
                 this.setMboxLabel(this.view);


### PR DESCRIPTION
Android 5 requires Outbox and Drafts folders to consider a FolderSync successful, otherwise the ActiveSync account will be reset and calendars and contacts will not show up. This error will probably only show up when configuring an account with only calendar and/or contacts, i.e. no e-mail is present. In this case Horde creates necessary dummy folders, but no Outbox or Drafts folders where created, which caused Android 5 to reset the account.
Tested on a Nexus 4 with Android 5.0.1.