### PR TITLE
add ThreadTopic class

### DIFF
--- a/framework/Mime/lib/Horde/Mime/Headers/ThreadTopic.php
+++ b/framework/Mime/lib/Horde/Mime/Headers/ThreadTopic.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright 2014-2015 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file COPYING for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2014-2015 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Mime
+ */
+/**
+ * This class represents the Thread-Topic header value (RFC 5322).
+ *
+ * @author    Klaus Leithoff <mail@leithoff.net>
+ * @category  Horde
+ * @copyright 2014-2015 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Mime
+ * @since     2.5.0
+ */
+class Horde_Mime_Headers_ThreadTopic
+extends Horde_Mime_Headers_Element_Single
+{
+    /**
+     */
+    public function __construct($name, $value)
+    {
+        parent::__construct('Thread-Topic', $value);
+    }
+    /**
+     */
+    protected function _sendEncode($opts)
+    {
+        return array(Horde_Mime::encode($this->value, $opts['charset']));
+    }
+    /**
+     */
+    public static function getHandles()
+    {
+        return array(
+            // Mail: RFC 5322
+            'thread-topic'
+        );
+    }
+}


### PR DESCRIPTION
as Threaded Mailhandling becomes more and more frequent the usage of the
Header fields Thread-Index and Thread-Topic increases a lot.
As Thread-Topic may hold about anything the user is able to type in, I suggest
the handling of Thread-Topic similar to Subject to avoid error messages
regarding enencoded utf-8 header fields.
Suggested Solution:
Add a new Header-Field Handling Class