### PR TITLE
Fix for PHP Fatal error: Class 'Horde_Compress_Tnef_Icalendar' not found

### DIFF
--- a/framework/Compress/lib/Horde/Compress/Tnef/Icalendar.php
+++ b/framework/Compress/lib/Horde/Compress/Tnef/Icalendar.php
@@ -23,7 +23,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Compress
  */
-class Horde_Compress_Tnef_ICalendar extends Horde_Compress_Tnef_Object
+class Horde_Compress_Tnef_Icalendar extends Horde_Compress_Tnef_Object
 {
     const PART_ACTION    = 'NEEDS-ACTION';
     const PART_TENTATIVE = 'TENTATIVE';


### PR DESCRIPTION
Wrong case in class-name causes Composer autoloader to not find the class, when Horde_Compress_Tnef eg. in line 621 does a new Horde_Compress_Tnef_Icalendar();

Should be easy to reproduce in Horde when you view a meeting request encapsulated as TNEF/winmail.dat.

Ralf