### PR TITLE
Fix error when changing start event date with attendees info already displayed

### DIFF
--- a/kronolith/js/kronolith.js
+++ b/kronolith/js/kronolith.js
@@ -6353,6 +6353,9 @@ KronolithCore = {
         if (!start) {
             start = Date.parseExact($F('kronolithEventStartDate'), Kronolith.conf.date_format);
         }
+        if (Object.isString(start)){
+            start = Date.parseExact(start, Kronolith.conf.date_format);   
+        }
         var end = start.clone().add(1).days(),
             width = td.getWidth(),
             fbs = this.parseDate(fb.s),


### PR DESCRIPTION
When there are some attendees with free busy information in an event and you change the start date, fbStartDateHandler is called with that date as string recovered from the field (https://github.com/horde/horde/blob/master/kronolith/js/kronolith.js#L6819), and then it ends in a call to insertFreeBusy with start param as string. It must be converted to Date