### PR TITLE
On exception $range is not set, moving up to avoid php error

### DIFF
--- a/imp/lib/Ajax/Imple/ItipRequest.php
+++ b/imp/lib/Ajax/Imple/ItipRequest.php
@@ -90,11 +90,11 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
                 if ($registry->hasMethod('calendar/delete')) {
                     $guid = $components[$key]->getAttribute('UID');
                     $recurrenceId = null;
+                    $range = null;
                     try {
                         // This is a cancellation of a recurring event instance.
                         $recurrenceId = $components[$key]->getAttribute('RECURRENCE-ID');
                         $atts = $components[$key]->getAttribute('RECURRENCE-ID', true);
-                        $range = null;
                         foreach ($atts as $att) {
                             if (array_key_exists('RANGE', $att)) {
                                 $range = $att['RANGE'];


### PR DESCRIPTION
Hello,

i noticed one php error when i tried to delete one event using itip action on imp,

the event has been deleted previously, so i have one exception in block code starting at line 94.

$range is not set when kronolith API is called on line 106

moving up avoids the error and has no other side effect, i think.

thanks in advance.