### PR TITLE
Added missing global variable

### DIFF
--- a/kronolith/lib/Event.php
+++ b/kronolith/lib/Event.php
@@ -3136,6 +3136,8 @@ abstract class Kronolith_Event
      */
     protected function _handleResources(Kronolith_Event $existing = null)
     {
+        global $session;
+
         if (Horde_Util::getFormData('isajax', false)) {
             $resources = array();
         } else {


### PR DESCRIPTION
Catched this error,

PHP Fatal error:  Call to a member function get() on a non-object in (...)/kronolith/lib/Event.php on line 3149

missing session variable,

setting as global, on beginning of the function, fixes the error.

The commit that introduced this error is this:

thttps://github.com/horde/horde/commit/10237a37fb797785e4a44d416e0e4552bea26dad

Thanks in advance