### PR TITLE
fixes PHP Strict standards error

### DIFF
--- a/framework/Tree/lib/Horde/Tree/Renderer/Base.php
+++ b/framework/Tree/lib/Horde/Tree/Renderer/Base.php
@@ -137,7 +137,7 @@ abstract class Horde_Tree_Renderer_Base
      *
      * @return string  The tree rendering.
      */
-    protected function _buildTree($id)
+    protected function _buildTree($node_id, $special=null)
     {
         return '';
     }

--- a/framework/Tree/lib/Horde/Tree/Renderer/Base.php
+++ b/framework/Tree/lib/Horde/Tree/Renderer/Base.php
@@ -137,7 +137,7 @@ abstract class Horde_Tree_Renderer_Base
      *
      * @return string  The tree rendering.
      */
-    protected function _buildTree($node_id, $special=null)
+    protected function _buildTree($id)
     {
         return '';
     }

--- a/imp/lib/Ajax/Application/Handler/Smartmobile.php
+++ b/imp/lib/Ajax/Application/Handler/Smartmobile.php
@@ -72,7 +72,7 @@ extends Horde_Core_Ajax_Application_Handler
     {
         $result = $this->_base->callAction('getForwardData');
 
-        if ($result && $result->opts->attach) {
+        if ($result && !empty($result->opts->attach)) {
             $GLOBALS['notification']->push(_("Forwarded message will be automatically added to your outgoing message."), 'horde.message');
         }
 


### PR DESCRIPTION
Hello,

in imp, smartmobile view, in folders page i notice one php strict standards error:

PHP Strict standards:  Declaration of Horde_Tree_Renderer_Jquerymobile::_buildTree() should be compatible with Horde_Tree_Renderer_Base::_buildTree($id)

my patch fixes the error, but i think that class Horde_Tree_Renderer_Base "API" is broken because Horde_Tree_Renderer_Jquerymobile::_buildTree() has 2 arguments instead of 1 like all other classes have...

Thanks in advance