### PR TITLE
fix mailbox name does not return in utf7

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
@@ -1670,9 +1670,8 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
      */
     protected function _parseStatus(Horde_Imap_Client_Tokenize $data)
     {
-        // Mailbox name is in UTF7-IMAP
         $mbox_ob = $this->_mailboxOb(
-            Horde_Imap_Client_Mailbox::get($data->next(), true)
+            $data->next()
         );
 
         $data->next();


### PR DESCRIPTION
This caused Imap Client Mailbox status() to return NULL on all mailbox that contains non-ASCII in the mailbox name (like `äöü`).
Tested on Gmail.