### PR TITLE
Fix string expected

### DIFF
--- a/framework/Mail/lib/Horde/Mail/Transport/Mail.php
+++ b/framework/Mail/lib/Horde/Mail/Transport/Mail.php
@@ -60,7 +60,7 @@ class Horde_Mail_Transport_Mail extends Horde_Mail_Transport
     public function send($recipients, array $headers, $body)
     {
         $headers = $this->_sanitizeHeaders($headers);
-        $recipients = $this->parseRecipients($recipients);
+        $recipients = implode(',', $this->parseRecipients($recipients));
         $subject = '';
 
         foreach (array_keys($headers) as $hdr) {


### PR DESCRIPTION
We use the great Horde_Mail lib for https://github.com/owncloud/mail and getting this error:

```
556 {"reqId":"SXF2i8qT\/tzWR9JfX3t5","remoteAddr":"127.0.0.1","app":"PHP","message":"mail() expects parameter 1 to be string, array given at \/home\/gomez\/public_html\/mail_dev\/core\/apps\/mail\/vendor\/pear-pear.horde.org\/Horde_Mail\/Horde\/Mail\/Transport\/Mail.php#103","level":3,"time":"2015-06-24T12:20:3    5+00:00"}
```

This PR fixes the bug, is it good to get merged?
