### PR TITLE
Update Icalendar.php

### DIFF
--- a/framework/Icalendar/lib/Horde/Icalendar.php
+++ b/framework/Icalendar/lib/Horde/Icalendar.php
@@ -1540,6 +1540,10 @@ class Horde_Icalendar
                 $duration .= $value . 'S';
             }
         }
+		// duration without time ("P") is NOT valid, append 0 seconds ("T0S")
+		elseif ($duration === 'P') {
+			$duration .= 'T0S';
+		}
 
         return $duration;
     }


### PR DESCRIPTION
You currently create:
TRIGGER;VALUE=DURATION:P
for an alarm right at event-time.
Apple clients ignore these kind of alarms and as I read https://tools.ietf.org/html/rfc5545#section-3.3.6 it is not valid.
Patch adds 0s so it renders as:
TRIGGER;VALUE=DURATION:PT0S
Can we please merge this.
Ralf