### PR TITLE
catch translation exception when there is server response exception

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Exception.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Exception.php
@@ -260,7 +260,9 @@ class Horde_Imap_Client_Exception extends Horde_Exception_Wrapped
         parent::__construct($message, $code);
 
         $this->raw_msg = $this->message;
-        $this->message = Horde_Imap_Client_Translation::t($this->message);
+        try {
+            $this->message = Horde_Imap_Client_Translation::t($this->message);
+        } catch (Horde_Translation_Exception $e) {}
     }
 
     /**


### PR DESCRIPTION
Translation exception hides Horde_Imap_Client_Exception.
I am trying to list all mailboxes. If I catch this exception then command continues and I get list of mailboxes. 

I believe error translations should not be a requirement.

Debug log when connecting to gmail and translation exception is NOT caught:
```
C: 3 ENABLE CONDSTORE UTF8=ACCEPT
C: 4 LIST () "" (*)
S: * ENABLED CONDSTORE UTF8=ACCEPT
S: 3 OK Success
>> Command 3 took 0.1214 seconds.
S: 4 BAD Could not parse command
>> Command 4 took 0.1214 seconds.
C: 5 LOGOUT
S: * BYE LOGOUT Requested
S: 5 OK 73 good day (Success)
>> Command 5 took 0.1196 seconds.
```
and when translation exception is caught:
```
C: 3 ENABLE CONDSTORE UTF8=ACCEPT
C: 4 LIST () "" (*)
S: * ENABLED CONDSTORE UTF8=ACCEPT
S: 3 OK Success
>> Command 3 took 0.121 seconds.
S: 4 BAD Could not parse command
>> Command 4 took 0.1211 seconds.
C: 5 LIST "" *
S: * LIST (\HasChildren \Noselect) "/" "[Gmail]"
S: * LIST (\All \HasNoChildren) "/" "[Gmail]/All Mail"
S: * LIST (\Drafts \HasNoChildren) "/" "[Gmail]/Drafts"
S: * LIST (\HasNoChildren \Important) "/" "[Gmail]/Important"
S: * LIST (\HasNoChildren \Sent) "/" "[Gmail]/Sent Mail"
S: * LIST (\HasNoChildren \Junk) "/" "[Gmail]/Spam"
S: * LIST (\Flagged \HasNoChildren) "/" "[Gmail]/Starred"
S: * LIST (\HasNoChildren \Trash) "/" "[Gmail]/Trash"
S: 5 OK Success
>> Command 5 took 0.1221 seconds.
```