### PR TITLE
Fix failed test with newer glibc

### DIFF
--- a/framework/Util/test/Horde/Util/TransliterateTest.php
+++ b/framework/Util/test/Horde/Util/TransliterateTest.php
@@ -79,9 +79,9 @@ class Horde_Util_TransliterateTest extends PHPUnit_Framework_TestCase
             // No normalization
             array('ABC123abc', 'ABC123abc'),
             // Non-ascii can all be transliterated
-            array('AÀBÞEÉSß', 'AAB?EESss'),
+            array('AÀBEÉSß', 'AABEESss'),
             // Some non-ascii cannot be transliterated
-            array('AÀ黾BÞ', 'AA?B?')
+            array('AÀ黾B', 'AA?B')
         );
     }
 


### PR DESCRIPTION
This is related to iconv, where "Þ" is now translated as "TH"
(like with intl).

Fedora rawhide, glibc 2.21.90:

    $ php -r 'var_dump(iconv("UTF-8", "ASCII//TRANSLIT", "Þ"));'
    string(2) "TH"

Fedora 21, glibc 2.20:

    $ php -r 'var_dump(iconv("UTF-8", "ASCII//TRANSLIT", "Þ"));'
    string(1) "?"

Detected by Fedora CI (aka Koschei) See https://apps.fedoraproject.org/koschei/package/php-horde-Horde-Util