### PR TITLE
Provide sane default arguments

### DIFF
--- a/ansel/lib/Image.php
+++ b/ansel/lib/Image.php
@@ -975,7 +975,7 @@ class Ansel_Image implements Iterator
      * @param string $view    The view (size) to work with.
      * @param integer $angle  What angle to rotate the image by.
      */
-    public function rotate($view = 'full', $angle)
+    public function rotate($view = 'full', $angle = 90)
     {
         $this->load($view);
         $this->_dirty = true;

--- a/luxor/lib/Driver/sql.php
+++ b/luxor/lib/Driver/sql.php
@@ -168,7 +168,7 @@ class Luxor_Driver_sql extends Luxor_Driver {
      *
      * @return integer              A unique ID for this file or PEAR_Error on error.
      */
-    function createFileId($filename, $tag = '', $lastmodified)
+    function createFileId($filename, $tag = '', $lastmodified = false)
     {
         $this->_connect();
 
@@ -176,6 +176,9 @@ class Luxor_Driver_sql extends Luxor_Driver {
         if (is_a($fileId, 'PEAR_Error')) {
             return $fileId;
         }
+
+        if ($lastmodified === false)
+            $lastmodified = time();
 
         /* Create an ID for this file. */
         $query = 'INSERT INTO luxor_files (fileid, filename, source, tag, lastmodified) VALUES (?, ?, ?, ?, ?)';

--- a/turba/lib/Driver/Group.php
+++ b/turba/lib/Driver/Group.php
@@ -22,7 +22,7 @@ class Turba_Driver_Group extends Turba_Driver
      *                       Basically, just passes the group id.
      *
      */
-    public function __construct($name = '', $params)
+    public function __construct($name = '', $params = array())
     {
          $this->_gid = $params['gid'];
     }

--- a/turba/lib/Driver/Imsp.php
+++ b/turba/lib/Driver/Imsp.php
@@ -72,7 +72,7 @@ class Turba_Driver_Imsp extends Turba_Driver
      * @param array $params  Hash containing additional configuration
      *                       parameters.
      */
-    public function __construct($name = '', $params)
+    public function __construct($name = '', $params = array())
     {
         parent::__construct($name, $params);
 
@@ -102,7 +102,7 @@ class Turba_Driver_Imsp extends Turba_Driver
      *
      * @return array  Hash containing the search results.
      */
-    protected function _search(array $criteria, array $fields, array $blobFields = array(), $count_only)
+    protected function _search(array $criteria, array $fields, array $blobFields = array(), $count_only = false)
     {
         $query = $results = array();
 


### PR DESCRIPTION
Default arguments have to be at the end of the argument list.
There's no way to skip parameters as in python.

Please have a careful look if the change
in luxor is correct or drop it otherwise.
