### PR TITLE
Kolab_Storage: Fix sync race condition when using sync token

### DIFF
--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Driver/Imap.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Driver/Imap.php
@@ -426,7 +426,10 @@ extends Horde_Kolab_Storage_Driver_Base
      */
     public function getStampFromToken($folder, $token, array $ids)
     {
+        // always get folder status first, then sync()
+        $status = $this->status($folder);
         $sync = $this->sync($folder, $token, $ids);
+
         $ids = array_diff(
             $ids,
             $sync[Horde_Kolab_Storage_Folder_Stamp_Uids::DELETED]
@@ -436,7 +439,7 @@ extends Horde_Kolab_Storage_Driver_Base
             $sync[Horde_Kolab_Storage_Folder_Stamp_Uids::ADDED]
         );
         return new Horde_Kolab_Storage_Folder_Stamp_Uids(
-            $this->status($folder),
+            $status,
             $ids
         );
     }


### PR DESCRIPTION
When using the new sync token strategy, we have to get
the folder status before calling sync(). That's the same
way the non-token based sync works.

Internally, Horde_Imap_Client uses "uidnext" to determine
if there are any new messages. If we first sync and then
get the folder status (and we force a status refresh in our
status() function), we might write down a higher
"uidnext" value than the one used for the sync() call.

This fixes vanishing contacts on changes from foreign Kolab clients
when using turba and ActiveSync at the same time: We didn't register
the new message (=updated contact), only the delete of the old IMAP message.