### PR TITLE
Imap_Client: Add new debug_pid parameter

### DIFF
--- a/framework/Core/lib/Horde/Core/Factory/KolabStorage.php
+++ b/framework/Core/lib/Horde/Core/Factory/KolabStorage.php
@@ -105,6 +105,9 @@ class Horde_Core_Factory_KolabStorage extends Horde_Core_Factory_Base
                 'debug'    => isset($configuration['debug'])
                     ? $configuration['debug']
                     : null,
+                'debug_pid'    => isset($configuration['debug_pid'])
+                    ? $configuration['debug_pid']
+                    : null,
                 'cache' =>  array(
                     'backend' => new Horde_Imap_Client_Cache_Backend_Cache(
                         array('cacheob' => $cacheob)

--- a/framework/Imap_Client/lib/Horde/Imap/Client/Base.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Base.php
@@ -202,6 +202,8 @@ implements Serializable, SplObserver
      *          provided. The value can be any PHP supported wrapper that can
      *          be opened via PHP's fopen() function.
      *          DEFAULT: No debug output
+     * - debug_pid: (boolean) Include pid in debug output.
+     *              DEFAULT: false
      * - hostspec: (string) The hostname or IP address of the server.
      *             DEFAULT: 'localhost'
      * - id: (array) Send ID information to the server (only if server
@@ -303,8 +305,9 @@ implements Serializable, SplObserver
         // @todo: Remove (BC)
         $this->_alerts->attach($this);
 
+        $debug_pid = $this->getParam('debug_pid');
         $this->_debug = ($debug = $this->getParam('debug'))
-            ? new Horde_Imap_Client_Base_Debug($debug)
+            ? new Horde_Imap_Client_Base_Debug($debug, $debug_pid)
             : new Horde_Support_Stub();
 
         // @todo: Remove (BC purposes)

--- a/framework/Imap_Client/lib/Horde/Imap/Client/Base/Debug.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Base/Debug.php
@@ -39,6 +39,13 @@ class Horde_Imap_Client_Base_Debug
     public $debug = true;
 
     /**
+     * Prefix log lines with pid?
+     *
+     * @var boolean
+     */
+    protected $_prefix_pid = false;
+
+    /**
      * The debug stream.
      *
      * @var resource
@@ -55,14 +62,17 @@ class Horde_Imap_Client_Base_Debug
     /**
      * Constructor.
      *
-     * @param mixed $debug  The debug target.
+     * @param mixed $debug       The debug target.
+     * @param mixed $prefix_pid  Prefix log lines with pid.
      */
-    public function __construct($debug)
+    public function __construct($debug, $prefix_pid = false)
     {
         $this->_stream = is_resource($debug)
             ? $debug
             : @fopen($debug, 'a');
         register_shutdown_function(array($this, 'shutdown'));
+
+        $this->_prefix_pid = $prefix_pid;
     }
 
     /**
@@ -127,6 +137,9 @@ class Horde_Imap_Client_Base_Debug
         if (!$this->debug || !$this->_stream) {
             return;
         }
+
+        if ($this->_prefix_pid)
+            fwrite($this->_stream, "[pid ".getmypid()."] ");
 
         if (!is_null($pre)) {
             $new_time = microtime(true);


### PR DESCRIPTION
The new debug_pid parameter allows you to prefix the
IMAP log file entries with the current PID.
    
This helps debugging concurrent access from multiple processes.
In my case that was a Kolab backend + web UI + ActiveSync.
