### PR TITLE
Determine contact picture MIME type when importing from ActiveSync

### DIFF
--- a/turba/lib/Driver.php
+++ b/turba/lib/Driver.php
@@ -2808,6 +2808,7 @@ class Turba_Driver implements Countable
         // picture ($message->picture *should* already be base64 encdoed)
         if (!$message->isGhosted('picture')) {
             $hash['photo'] = base64_decode($message->picture);
+            $hash['phototype'] = Horde_Mime_Magic::analyzeData($hash['photo']);
         }
 
         /* Email addresses */


### PR DESCRIPTION
Fixes contact picture import when using a Kolab backend.
Without the MIME type, the driver ignores the photo on IMAP writeout.