### PR TITLE
Determine contact picture mime type when importing from ActiveSync

### DIFF
--- a/turba/lib/Driver.php
+++ b/turba/lib/Driver.php
@@ -2808,6 +2808,10 @@ class Turba_Driver implements Countable
         // picture ($message->picture *should* already be base64 encdoed)
         if (!$message->isGhosted('picture')) {
             $hash['photo'] = base64_decode($message->picture);
+            if (!empty($hash['photo']))
+                $hash['phototype'] = Horde_Mime_Magic::analyzeData($hash['photo']);
+            else
+                $hash['phototype'] = null;
         }
 
         /* Email addresses */


### PR DESCRIPTION
Fixes contact picture import when using a Kolab backend.
Without the mime type, the driver ignores the photo on IMAP writeout.

Also handles the case when a contact picture gets deleted
by setting 'phototype' to null.