### PR TITLE
Fix picture tag quirk for iOS 4.x

### DIFF
--- a/framework/ActiveSync/lib/Horde/ActiveSync/Message/Contact.php
+++ b/framework/ActiveSync/lib/Horde/ActiveSync/Message/Contact.php
@@ -450,8 +450,8 @@ class Horde_ActiveSync_Message_Contact extends Horde_ActiveSync_Message_Base
     {
         $isGhosted = parent::isGhosted($property);
         if (!$isGhosted &&
-            $property == self::PICTURE &&
-            $this->_device->hasQuirk(Horde_ActiveSYnc_Device::QUIRK_NEEDS_SUPPORTED_PICTURE_TAG)) {
+            $property == $this->_mapping[self::PICTURE][self::KEY_ATTRIBUTE] &&
+            $this->_device->hasQuirk(Horde_ActiveSync_Device::QUIRK_NEEDS_SUPPORTED_PICTURE_TAG)) {
             return true;
         }
 

--- a/framework/ActiveSync/test/Horde/ActiveSync/ContactTest.php
+++ b/framework/ActiveSync/test/Horde/ActiveSync/ContactTest.php
@@ -41,7 +41,7 @@ class Horde_ActiveSync_ContactTest extends Horde_Test_Case
         );
         $device = new Horde_ActiveSync_Device($state, $fixture);
         $contact = new Horde_ActiveSync_Message_Contact(array('device' => $device));
-        $this->assertEquals(true, $contact->isGhosted(Horde_ActiveSync_Message_Contact::PICTURE));
+        $this->assertEquals(true, $contact->isGhosted('picture'));
 
         $fixture = array(
             'deviceType' => 'iPad',
@@ -50,7 +50,7 @@ class Horde_ActiveSync_ContactTest extends Horde_Test_Case
         );
         $device = new Horde_ActiveSync_Device($state, $fixture);
         $contact = new Horde_ActiveSync_Message_Contact(array('device' => $device));
-        $this->assertEquals(false, $contact->isGhosted(Horde_ActiveSync_Message_Contact::PICTURE));
+        $this->assertEquals(false, $contact->isGhosted('picture'));
     }
 
     /**


### PR DESCRIPTION
- Map the field name before checking for 'picture'
- Fix typo in class name: Horde_ActiveSYnc_Device -> Horde_ActiveSync_Device
