### PR TITLE
bump Socket_Client and Nls supported PHP version to 7

### DIFF
--- a/framework/Nls/package.xml
+++ b/framework/Nls/package.xml
@@ -317,8 +317,8 @@
   <required>
    <php>
     <min>5.3.0</min>
-    <max>6.0.0alpha1</max>
-    <exclude>6.0.0alpha1</exclude>
+    <max>8.0.0alpha1</max>
+    <exclude>8.0.0alpha1</exclude>
    </php>
    <pearinstaller>
     <min>1.7.0</min>

--- a/framework/Socket_Client/package.xml
+++ b/framework/Socket_Client/package.xml
@@ -51,8 +51,8 @@
   <required>
    <php>
     <min>5.3.0</min>
-    <max>6.0.0alpha1</max>
-    <exclude>6.0.0alpha1</exclude>
+    <max>8.0.0alpha1</max>
+    <exclude>8.0.0alpha1</exclude>
    </php>
    <pearinstaller>
     <min>1.7.0</min>


### PR DESCRIPTION
I have carefully tested these 2 frameworks and they both play well with php7.

We need this to bump our projects supported version.
https://github.com/owncloud/mail/pull/1262