### PR TITLE
ScriptTester has a deprecated constructor

### DIFF
--- a/ingo/test/Ingo/Unit/ScriptTest.php
+++ b/ingo/test/Ingo/Unit/ScriptTest.php
@@ -93,7 +93,7 @@ class ScriptTester {
     protected $test;
     protected $rules = array();
 
-    function ScriptTester($test)
+    function __construct($test)
     {
         $this->test = $test;
     }


### PR DESCRIPTION
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; ScriptTester has a deprecated constructor