### PR TITLE
For recuring events exported to ICAL make the "due" date represent th…

### DIFF
--- a/nag/lib/Task.php
+++ b/nag/lib/Task.php
@@ -1327,7 +1327,13 @@ class Nag_Task
         }
 
         if ($this->due) {
-            $vTodo->setAttribute('DUE', $this->due);
+            if($this->recurs()) {
+                $d = $this->recurrence->nextActiveRecurrence(new Horde_Date($this->due));
+                $vTodo->setAttribute('DUE', $d);
+            } else {
+                $vTodo->setAttribute('DUE', $this->due);
+            }
+
 
             if ($this->alarm) {
                 if ($v1) {


### PR DESCRIPTION
…e next time the event is due, rather than the first time it was due.

The right fix would be to export them as recuring events, but that would
require a lot more effort, and I'm not familiar enough with Horde to make
that change.

-- nathan@lstc.com
