### PR TITLE
Add support for SMTP via TLS

### DIFF
--- a/framework/ActiveSync/lib/Horde/ActiveSync/Request/Autodiscover.php
+++ b/framework/ActiveSync/lib/Horde/ActiveSync/Request/Autodiscover.php
@@ -179,6 +179,16 @@ class Horde_ActiveSync_Request_Autodiscover extends Horde_ActiveSync_Request_Bas
                     </Protocol>';
             }
             if (!empty($properties['smtp'])) {
+                switch ($properties['smtp']['ssl']) {
+                case 'ssl':
+                  $encryption = '<SSL>on</SSL>';
+                  break;
+                case 'tls':
+                  $encryption = '<Encryption>TLS</Encryption>';
+                  break;
+                default:
+                  $encryption = '<SSL>off</SSL>';
+                }
                 $xml .= '<Protocol>
                     <Type>SMTP</Type>
                     <Server>' . $properties['smtp']['host'] . '</Server>
@@ -186,7 +196,7 @@ class Horde_ActiveSync_Request_Autodiscover extends Horde_ActiveSync_Request_Bas
                     <LoginName>' . $properties['username'] . '</LoginName>
                     <DomainRequired>off</DomainRequired>
                     <SPA>off</SPA>
-                    <SSL>' . ($properties['smtp']['ssl'] ? 'on' : 'off') . '</SSL>
+                    ' . $encryption . '
                     <AuthRequired>on</AuthRequired>
                     <UsePOPAuth>' . ($properties['smtp']['popauth'] ? 'on' : 'off') . '</UsePOPAuth>
                     </Protocol>';

--- a/horde/config/conf.xml
+++ b/horde/config/conf.xml
@@ -2386,7 +2386,13 @@
              <configstring name="host" desc="SMTP host"></configstring>
              <configinteger name="port" desc="SMTP port" required="false"></configinteger>
              <configboolean name="popauth" desc="Require Pop Auth?" required="false" />
-             <configboolean name="ssl" desc="Use SSL?" />
+             <configenum name="ssl" desc="Use SSL?">
+               <values>
+                 <value desc="No">no</value>
+                 <value desc="SSL">ssl</value>
+                 <value desc="TLS">tls</value>
+               </values>
+             </configenum>
            </configsection>
          </configsection>
        </case>


### PR DESCRIPTION
Based on several documentations it's also possible to set the encryption type from outlook not only to SSL but also to TLS. (See http://microsoft.public.office.xml.narkive.com/PgCJxeuz/autodiscover-xml-and-tls)
With this patch it's possible to decide whether the setting is set to NO/SSL/TLS.
The only new setting is TLS. In case of "off" and "ssl" the previous syntax of the xml file is used.

I am just unsure whether I am allowed to use the $properties['smtp']['ssl'] due to compatibility reasons?