### PR TITLE
Send ITIP_REPLY message when saving ext. event

### DIFF
--- a/kronolith/lib/Icalendar/Handler/Dav.php
+++ b/kronolith/lib/Icalendar/Handler/Dav.php
@@ -169,18 +169,19 @@ class Kronolith_Icalendar_Handler_Dav extends Kronolith_Icalendar_Handler_Base
             $this->_dav->addObjectMap($event->id, $this->_params['object'], $this->_calendar);
         }
 
-        // Send iTip messages unless organizer is external.
+        // Send iTip messages
         // Notifications will get lost, there is no way to return messages
         // to clients.
+	$type = Kronolith::ITIP_REQUEST;
         if ($event->organizer && !Kronolith::isUserEmail($event->creator, $event->organizer)) {
-            return;
+            $type = Kronolith::ITIP_REPLY;
         }
         $event_copy = clone($event);
         $event_copy->attendees = $event->attendees->without($this->_noItips);
         Kronolith::sendITipNotifications(
             $event_copy,
             new Horde_Notification_Handler(new Horde_Notification_Storage_Object()),
-            Kronolith::ITIP_REQUEST
+            $type
         );
     }
 


### PR DESCRIPTION
There are still things I'm not sure about:
- if I should add a check if the event (or in the case of ext. organizer, if the attendance response) has been changed before sending the ITip notification
- what is with the davDeleteObject method from lib/Application.php? (maybe the ITIP_CANCEL should be changed to ITIP_REPLY too, and the attendance response to decline?)