### PR TITLE
for PHP 7, use alcaeus/mongo-php-adapter 

### DIFF
--- a/framework/Cache/test/Horde/Cache/MongoTest.php
+++ b/framework/Cache/test/Horde/Cache/MongoTest.php
@@ -23,8 +23,8 @@ class Horde_Cache_MongoTest extends Horde_Cache_TestBase
 {
     protected function _getCache($params = array())
     {
-        if (!extension_loaded('mongo')) {
-            $this->reason = 'Mongo extension not loaded';
+        if (!extension_loaded('mongo') && !extension_loaded('mongodb')) {
+            $this->reason = 'Mongo/Mongodb extensions not loaded';
             return;
         }
         if (!class_exists('Horde_Mongo_Client')) {

--- a/framework/Mongo/bundle/composer.json
+++ b/framework/Mongo/bundle/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "alcaeus/mongo-php-adapter": "^1.0.3"
+    }
+}

--- a/framework/Mongo/lib/Horde/Mongo/Client.php
+++ b/framework/Mongo/lib/Horde/Mongo/Client.php
@@ -11,6 +11,15 @@
  * @package   Mongo
  */
 
+if (!extension_loaded('mongo')) {
+    // use the compatibility layer and mongodb extension
+    if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+        require_once __DIR__ . '/vendor/autoload.php'; // PEAR installation
+    } else {
+        require_once __DIR__ . '/../../../bundle/vendor/autoload.php'; // GIT
+    }
+}
+
 /**
  * Extend the base PECL MongoClient class by allowing it to be serialized.
  *

--- a/framework/Test/lib/Horde/Test/Factory/Mongo.php
+++ b/framework/Test/lib/Horde/Test/Factory/Mongo.php
@@ -41,7 +41,7 @@ class Horde_Test_Factory_Mongo
     {
         $mongo = null;
 
-        if (extension_loaded('mongo') &&
+        if ((extension_loaded('mongo') || extension_loaded('mongodb')) &&
             class_exists('Horde_Mongo_Client') &&
             !empty($params['config'])) {
             try {


### PR DESCRIPTION
use alcaeus/mongo-php-adapter  compatibility layer and mongodb extension

With PHP 5.6 and mongo extension
```
$ phpunit MongoTest.php  --verbose
PHPUnit 5.4.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 5.6.22
Configuration: /work/GIT/horde/framework/Cache/test/Horde/Cache/phpunit.xml

........                                                            8 / 8 (100%)

Time: 481 ms, Memory: 13.50MB

OK (8 tests, 21 assertions)
```

With PHP 7.0 and mongodb extension
```
$ phpunit MongoTest.php  --verbose
PHPUnit 5.4.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.8RC1
Configuration: /work/GIT/horde/framework/Cache/test/Horde/Cache/phpunit.xml

........                                                            8 / 8 (100%)

Time: 475 ms, Memory: 4.00MB

OK (8 tests, 21 assertions)

```
