### PR TITLE
fix PHP Fatal error: Class 'Horde\Auth_SASL' not found

### DIFF
--- a/framework/ManageSieve/lib/Horde/ManageSieve.php
+++ b/framework/ManageSieve/lib/Horde/ManageSieve.php
@@ -16,6 +16,7 @@
  */
 
 namespace Horde;
+use Auth_SASL;
 use Horde\Socket\Client;
 use Horde\ManageSieve\Exception;
 


### PR DESCRIPTION
One of our users run into an other namespace problem, which I fixed here.

Ralf