### PR TITLE
restrict post search "filtering on e-mail addresses matching search string" when there are multiple e-mail adresses per result

### DIFF
--- a/turba/lib/Api.php
+++ b/turba/lib/Api.php
@@ -1337,13 +1337,18 @@ class Turba_Api extends Horde_Registry_Api
                             : $ob->getValue($ob->driver->alternativeName);
                         unset($tdisplay_name);
 
+                        $possible_email_attrs = array();
                         foreach (array_keys($att) as $key) {
                             if ($ob->getValue($key) &&
                                 isset($attributes[$key]) &&
                                 ($attributes[$key]['type'] == 'email')) {
-                                $e_val = $ob->getValue($key);
+                                $possible_email_attrs[] = $key;
+                            }
+                        }
 
-                                if (strlen($trimname)) {
+                        foreach ($possible_email_attrs as $key) {
+                                $e_val = $ob->getValue($key);
+                                if (strlen($trimname) && count($possible_email_attrs) > 1) {
                                     /* Ticket #12480: Don't return email if it
                                      * doesn't contain the search string, since
                                      * an entry can contain multiple e-mail
@@ -1368,7 +1373,6 @@ class Turba_Api extends Horde_Registry_Api
                                         'limit' => (isset($attributes[$key]['params']) && is_array($attributes[$key]['params']) && !empty($attributes[$key]['params']['allow_multi'])) ? 0 : 1
                                     )));
                                 }
-                            }
                         }
 
                         if (count($email)) {


### PR DESCRIPTION
This limits the effects of request #12480.

Rationale: there is no reason to completely discard some search results.
Example: result for "Rigaux Pascal" (that matches our LDAP "cn") are discarded because my e-mail address is "Pascal.Rigaux@univ-paris1.fr".

Limitation: what should be done if 2 e-mail addresses are returned, none matching the search string?
Better fix would be to include all e-mails, but sort them?