### PR TITLE
Fix tarball generation for turba

### DIFF
--- a/turba/package.xml
+++ b/turba/package.xml
@@ -138,7 +138,6 @@
      <file name="Ldif.php" role="horde" />
     </dir> <!-- /lib/Data -->
     <dir name="Driver">
-     <file name="Facebook.php" role="horde" />
      <file name="Favourites.php" role="horde" />
      <file name="Group.php" role="horde" />
      <file name="Imsp.php" role="horde" />
@@ -945,7 +944,6 @@
    <install as="turba/lib/Ajax/Imple/TagAutoCompleter.php" name="lib/Ajax/Imple/TagAutoCompleter.php" />
    <install as="turba/lib/Block/Minisearch.php" name="lib/Block/Minisearch.php" />
    <install as="turba/lib/Data/Ldif.php" name="lib/Data/Ldif.php" />
-   <install as="turba/lib/Driver/Facebook.php" name="lib/Driver/Facebook.php" />
    <install as="turba/lib/Driver/Favourites.php" name="lib/Driver/Favourites.php" />
    <install as="turba/lib/Driver/Group.php" name="lib/Driver/Group.php" />
    <install as="turba/lib/Driver/Imsp.php" name="lib/Driver/Imsp.php" />


### PR DESCRIPTION
The "distribute" command silently failed but strace
showed it tried to access the removed Facebook driver.