### PR TITLE
Don't set port for unix:// connection types

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Base.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Base.php
@@ -249,7 +249,7 @@ implements Serializable, SplObserver
             'timeout' => 30
         ), array_filter($params));
 
-        if (!isset($params['port'])) {
+        if (!isset($params['port']) && strpos($params['hostspec'], 'unix://') !== 0) {
             $params['port'] = (!empty($params['secure']) && in_array($params['secure'], array('ssl', 'sslv2', 'sslv3'), true))
                 ? $this->_defaultPorts[1]
                 : $this->_defaultPorts[0];


### PR DESCRIPTION
Otherwise :143 was appended to the connection string
and it failed for unix sockets.

Thanks to Jan for implementing unix socket
support in the first place in Horde_Socket_Client.

Feel free to cherry-pick just this little commit.
