### PR TITLE
Fix UIDVALIDITY change detection

### DIFF
--- a/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Cached.php
+++ b/framework/Kolab_Storage/lib/Horde/Kolab/Storage/Data/Cached.php
@@ -262,7 +262,7 @@ extends Horde_Kolab_Storage_Data_Base
                 '[KOLAB_STORAGE] Complete folder sync: user: %s, folder: %s, is_reset: %d',
                 $user, $folder_path, $is_reset)
             );
-            $this->_completeSynchronization($current);
+            $this->_completeSynchronization($current, array('is_reset' => $is_reset));
             return;
         }
 


### PR DESCRIPTION
The 'is_reset' flag was lost during a
INFO -> DEBUG log level change in
commit 395635111ddde15dd9f0183d75d9be079cc728a5

Probably a botched merge since there were
two corrections to this code later on, too.

-> restore it. Originally introduced by bugs.horde.org entry #11807.

Feel free to cherry-pick this commit.