### PR TITLE
Kolab driver: Sync with backend before doing modify()

### DIFF
--- a/nag/lib/Driver/Kolab.php
+++ b/nag/lib/Driver/Kolab.php
@@ -350,6 +350,7 @@ class Nag_Driver_Kolab extends Nag_Driver
      */
     protected function _modify($taskId, array $task)
     {
+        $this->synchronize();
         $object = $this->_getObject($task);
         $object['uid'] = Horde_Url::uriB64Decode($taskId);
         try {


### PR DESCRIPTION
An entry might be updated by a foreign Kolab client
while we try to modify it. By doing a sync before calling modify(),
we reduce the time window of the race.

Found by comparing my local patch with the official code.
delete() or deleteAll() does this already.

It's cherry-picking season :cherries: