### PR TITLE
Kolab backend: Remove invalid argument from _getData() call

### DIFF
--- a/turba/lib/Driver/Kolab.php
+++ b/turba/lib/Driver/Kolab.php
@@ -1023,7 +1023,7 @@ class Turba_Driver_Kolab extends Turba_Driver
      */
     public function synchronize($token = false)
     {
-        $data = $this->_getData(true);
+        $data = $this->_getData();
         $last_token = $GLOBALS['session']->get('turba', 'kolab/token/' . $this->_name);
         if (empty($token) || empty($last_token) || $last_token != $token) {
             $GLOBALS['session']->set('turba', 'kolab/token/' . $this->_name, $token);


### PR DESCRIPTION
_getData() does not take any argument, yet we pass "true" to it.

This is a leftover from the upstream integration of my original patch:
The _getData() function contained a "$force=false" argument back then.

Another sweet :cherries:
