### PR TITLE
Fix wrong Horde_Nls version number in package.xml

### DIFF
--- a/kronolith/package.xml
+++ b/kronolith/package.xml
@@ -1000,7 +1000,7 @@
    <package>
     <name>Horde_Nls</name>
     <channel>pear.horde.org</channel>
-    <min>2.3.0</min>
+    <min>2.2.0</min>
     <max>3.0.0alpha1</max>
     <exclude>3.0.0alpha1</exclude>
    </package>


### PR DESCRIPTION
kronolith needs Horde_Nls 2.2.0 instead of 2.3.0.

2.3.0 is not released yet and Horde_Nls 2.2.2
contains all current changes.

:cherries: ;)
