### PR TITLE
fix PHP 5.3 compatibility

### DIFF
--- a/framework/Icalendar/lib/Horde/Icalendar.php
+++ b/framework/Icalendar/lib/Horde/Icalendar.php
@@ -1289,7 +1289,7 @@ class Horde_Icalendar
                 if (!$b['end']) {
                     return -1;
                 }
-                return $this->_getEndDifference($a['end'], $b['end']);
+                return Horde_Icalendar::_getEndDifference($a['end'], $b['end']);
             }
         );
 
@@ -1365,7 +1365,7 @@ class Horde_Icalendar
      *
      * @return boolean  True if $a < $b otherwise false.
      */
-    protected function _getEndDifference($a, $b)
+    public static function _getEndDifference($a, $b)
     {
         if (strlen($a) == 4) {
             $a = @gmmktime(0, 0, 0, 1, 1, $a);


### PR DESCRIPTION
From http://php.net/manual/en/functions.anonymous.php

`As of PHP 5.4.0, when declared in the context of a class, the current class is automatically bound to it, making $this available inside of the function's scope. `

So with PHP 5.3

```
+ php /usr/bin/phpunit --verbose .
PHPUnit 3.7.34 by Sebastian Bergmann.

Configuration read from /builddir/build/BUILD/php-horde-Horde-Icalendar-2.1.5/Horde_Icalendar-2.1.5/test/Horde/Icalendar/phpunit.xml

.....F...........PHP Fatal error:  Using $this when not in object context in /builddir/build/BUILD/php-horde-Horde-Icalendar-2.1.5/Horde_Icalendar-2.1.5/lib/Horde/Icalendar.php on 
```

Having to put this method public and static is a but ugly, but... I don't see other simple way