### PR TITLE
Unset HTTP Referer when following external links

### DIFF
--- a/framework/Core/lib/Horde/PageOutput.php
+++ b/framework/Core/lib/Horde/PageOutput.php
@@ -718,6 +718,8 @@ class Horde_PageOutput
             header('Vary: Accept-Language');
         }
 
+        header('Referrer-Policy: same-origin');
+
         echo $view->render('header');
         if ($this->topbar) {
             echo $injector->getInstance('Horde_View_Topbar')->render();


### PR DESCRIPTION
Keep user’s webmail provider private by unsetting the `Referer`
header when clicking through to or requesting any external resources.

https://www.w3.org/TR/referrer-policy/#referrer-policy-header
https://www.w3.org/TR/referrer-policy/#referrer-policy-same-origin