### PR TITLE
don't rely on directory entries order

### DIFF
--- a/framework/Compress/test/Horde/Compress/TarTest.php
+++ b/framework/Compress/test/Horde/Compress/TarTest.php
@@ -112,14 +112,20 @@ class Horde_Compress_TarTest extends Horde_Test_Case
 
         $list = $compress->decompress($tar_data);
         $this->assertCount(3, $list);
-        $this->assertEquals('one.txt', $list[0]['name']);
-        $this->assertEquals(4, $list[0]['size']);
-        $this->assertEquals("One\n", $list[0]['data']);
-        $this->assertEquals('sub/three.txt', $list[1]['name']);
-        $this->assertEquals(6, $list[1]['size']);
-        $this->assertEquals("Three\n", $list[1]['data']);
-        $this->assertEquals('two.bin', $list[2]['name']);
-        $this->assertEquals(2, $list[2]['size']);
-        $this->assertEquals("\x02\x0a", $list[2]['data']);
+        for ($i=0 ; $i<3 ; $i++) {
+            $list[$list[$i]['name']] = $list[$i];
+            unset($list[$i]);
+        }
+        $this->assertArrayHasKey($k='one.txt', $list);
+        $this->assertEquals(4, $list[$k]['size']);
+        $this->assertEquals("One\n", $list[$k]['data']);
+
+        $this->assertArrayHasKey($k='sub/three.txt', $list);
+        $this->assertEquals(6, $list[$k]['size']);
+        $this->assertEquals("Three\n", $list[$k]['data']);
+
+        $this->assertArrayHasKey($k='two.bin', $list);
+        $this->assertEquals(2, $list[$k]['size']);
+        $this->assertEquals("\x02\x0a", $list[$k]['data']);
     }
 }

--- a/framework/Compress/test/Horde/Compress/ZipTest.php
+++ b/framework/Compress/test/Horde/Compress/ZipTest.php
@@ -143,39 +143,45 @@ class Horde_Compress_ZipTest extends Horde_Test_Case
             $zip_data, array('action' => Horde_Compress_Zip::ZIP_LIST)
         );
         $this->assertCount(3, $list);
-        $this->assertEquals('one.txt', $list[0]['name']);
-        $this->assertEquals(4, $list[0]['size']);
-        $this->assertEquals('sub/three.txt', $list[1]['name']);
-        $this->assertEquals(6, $list[1]['size']);
-        $this->assertEquals('two.bin', $list[2]['name']);
-        $this->assertEquals(2, $list[2]['size']);
+        for ($i=0 ; $i<3 ; $i++) {
+            $index[$list[$i]['name']] = $i;
+        }
 
+        $this->assertArrayHasKey($k='one.txt', $index);
+        $this->assertEquals($k, $list[$index[$k]]['name']);
+        $this->assertEquals(4, $list[$index[$k]]['size']);
         $data = $compress->decompress(
             $zip_data,
             array(
                 'action' => Horde_Compress_Zip::ZIP_DATA,
                 'info' => $list,
-                'key' => 0
+                'key' => $index[$k]
             )
         );
         $this->assertEquals("One\n", $data);
 
+        $this->assertArrayHasKey($k='sub/three.txt', $index);
+        $this->assertEquals($k, $list[$index[$k]]['name']);
+        $this->assertEquals(6, $list[$index[$k]]['size']);
         $data = $compress->decompress(
             $zip_data,
             array(
                 'action' => Horde_Compress_Zip::ZIP_DATA,
                 'info' => $list,
-                'key' => 1
+                'key' => $index[$k]
             )
         );
         $this->assertEquals("Three\n", $data);
 
+        $this->assertArrayHasKey($k='two.bin', $index);
+        $this->assertEquals('two.bin', $list[$index[$k]]['name']);
+        $this->assertEquals(2, $list[$index[$k]]['size']);
         $data = $compress->decompress(
             $zip_data,
             array(
                 'action' => Horde_Compress_Zip::ZIP_DATA,
                 'info' => $list,
-                'key' => 2
+                'key' => $index[$k]
             )
         );
         $this->assertEquals("\x02\x0a", $data);


### PR DESCRIPTION
Test failing because entries order is not reliable.

```
PHPUnit 5.7.19 by Sebastian Bergmann and contributors.

Runtime:       PHP 5.6.30
Configuration: /dev/shm/BUILD/php-horde-Horde-Compress-2.2.0/Horde_Compress-2.2.0/test/Horde/Compress/phpunit.xml

.....F...........F                                                18 / 18 (100%)

Time: 242 ms, Memory: 18.00MB

There were 2 failures:

1) Horde_Compress_TarTest::testTarDirectory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'one.txt'
+'two.bin'

/dev/shm/BUILD/php-horde-Horde-Compress-2.2.0/Horde_Compress-2.2.0/test/Horde/Compress/TarTest.php:115

2) Horde_Compress_ZipTest::testZipDirectory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'one.txt'
+'two.bin'

/dev/shm/BUILD/php-horde-Horde-Compress-2.2.0/Horde_Compress-2.2.0/test/Horde/Compress/ZipTest.php:146

FAILURES!
Tests: 18, Assertions: 59, Failures: 2.
```

