### PR TITLE
'--pinentry-mode loopback' was introduce in gnupg 2.1.12

### DIFF
--- a/framework/Crypt/lib/Horde/Crypt/Pgp/Backend/Binary.php
+++ b/framework/Crypt/lib/Horde/Crypt/Pgp/Backend/Binary.php
@@ -80,8 +80,8 @@ extends Horde_Crypt_Pgp_Backend
 
         /* GnuPG 2 requires specifying the pinentry-mode. */
         $result = $this->_callGpg(array('--version'), 'r');
-        if (preg_match('/gpg \(GnuPG\) (\d+)\.(\d+)\.(\d+)/', $result->stdout, $version) &&
-            $version[1] >= 2) {
+        if (preg_match('/gpg \(GnuPG\) (\d+\.\d+\.\d+)/', $result->stdout, $version) &&
+            version_compare($version[1], '2.1.12', 'ge') ) {
             $this->_gnupg[] = '--pinentry-mode loopback';
             file_put_contents(
                 $this->_tempdir . '/gpg-agent.conf',


### PR DESCRIPTION
From gnupg NEWS file

```
Noteworthy changes in version 2.1.12 (2016-05-04)
-------------------------------------------------
...
 * gpgsm: Add option --pinentry-mode to support a loopback pinentry.
...
```

So, test suite fails on RHEL 6 (gnupg 2.0.14) and 7  (gnupg 2.0.22)

```
# phpunit .
PHPUnit 5.7.19 by Sebastian Bergmann and contributors.

FEEEEFFEEEFFE.EEF...                                              20 / 20 (100%)

Time: 151 ms, Memory: 5.25MB

There were 10 errors:

1) Horde_Crypt_Pgp_BinaryTest::testPgpDecrypt with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not decrypt PGP data.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:659
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:83

2) Horde_Crypt_Pgp_BinaryTest::testPgpDecryptSymmetric with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not decrypt PGP data.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:659
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:117

3) Horde_Crypt_Pgp_BinaryTest::testPgpEncrypt with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not PGP encrypt message.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:595
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:149

4) Horde_Crypt_Pgp_BinaryTest::testPgpEncryptSymmetric with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not PGP encrypt message.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:595
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:182

5) Horde_Crypt_Pgp_BinaryTest::testPgpPacketInformation with data set #0 (Horde_Crypt_Pgp Object (...))
PHPUnit_Framework_Exception: Argument #2 (No Value) of PHPUnit_Framework_Assert::assertArrayHasKey() must be a array or ArrayAccess

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:236

6) Horde_Crypt_Pgp_BinaryTest::testPgpPacketSignature with data set #0 (Horde_Crypt_Pgp Object (...))
Undefined index: keyid

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:290

7) Horde_Crypt_Pgp_BinaryTest::testPgpPacketSignatureByUidIndex with data set #0 (Horde_Crypt_Pgp Object (...))
Undefined index: keyid

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:326

8) Horde_Crypt_Pgp_BinaryTest::testPgpSign with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not PGP sign message.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:595
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:479

9) Horde_Crypt_Pgp_BinaryTest::testVerifyPassphraseCorrect with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not determine the recipient's e-mail address.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:431
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:578

10) Horde_Crypt_Pgp_BinaryTest::testVerifyPassphraseIncorrect with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not determine the recipient's e-mail address.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:431
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:592

--

There were 6 failures:

1) Horde_Crypt_Pgp_BinaryTest::testBug6601 with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Name:             Richard Selsky
-Key Type:         Public Key
-Key Creation:     04/11/08
-Expiration Date:  04/11/13
-Key Length:       1024 Bytes
-Comment:          [None]
-E-Mail:           rselsky@bu.edu
-Hash-Algorithm:   pgp-sha1
-Key ID:           0xF3C01D42
-Key Fingerprint:  5912D91D4C79C6701FFF148604A67B37F3C01D42
-
-'
+''

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:65

2) Horde_Crypt_Pgp_BinaryTest::testPgpEncryptedSymmetrically with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that false is true.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:212

3) Horde_Crypt_Pgp_BinaryTest::testGetSignersKeyID with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that null matches expected 'BADEABD7'.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:223

4) Horde_Crypt_Pgp_BinaryTest::testPgpPrettyKey with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Name:             My Name
-Key Type:         Public Key
-Key Creation:     08/11/06
-Expiration Date:  [Never]
-Key Length:       1024 Bytes
-Comment:          My Comment
-E-Mail:           me@example.com
-Hash-Algorithm:   pgp-sha1
-Key ID:           0xBADEABD7
-Key Fingerprint:  966F4BA9569DE6F65E8253977CA74426BADEABD7
-
-'
+''

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:371

5) Horde_Crypt_Pgp_BinaryTest::testPgpGetFingerprintsFromKey with data set #0 (Horde_Crypt_Pgp Object (...), array('966F4BA9569DE6F65E8253977CA74...DEABD7'), '-----BEGIN PGP PUBLIC KEY BLO...-----\n', array('966F4BA9569DE6F65E8253977CA74...DEABD7'), '-----BEGIN PGP PRIVATE KEY BL...-----\n')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    '0xBADEABD7' => '966F4BA9569DE6F65E8253977CA74...DEABD7'
 )

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:398

6) Horde_Crypt_Pgp_BinaryTest::testGetPublicKeyFromPrivateKey with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that null is not null.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:603

ERRORS!
Tests: 20, Assertions: 21, Errors: 10, Failures: 6.
<mock-chroot> sh-4.2# phpunit .
PHPUnit 5.7.19 by Sebastian Bergmann and contributors.

....................                                              20 / 20 (100%)

Time: 10.29 seconds, Memory: 4.50MB

OK (20 tests, 46 assertions)
<mock-chroot> sh-4.2# phpunit .
PHPUnit 5.7.19 by Sebastian Bergmann and contributors.

....................                                              20 / 20 (100%)

Time: 10.29 seconds, Memory: 4.50MB

OK (20 tests, 46 assertions)
<mock-chroot> sh-4.2# phpunit .
PHPUnit 5.7.19 by Sebastian Bergmann and contributors.

FEEEEFFEEEFFE.EEF...                                              20 / 20 (100%)

Time: 154 ms, Memory: 5.25MB

There were 10 errors:

1) Horde_Crypt_Pgp_BinaryTest::testPgpDecrypt with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not decrypt PGP data.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:659
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:83

2) Horde_Crypt_Pgp_BinaryTest::testPgpDecryptSymmetric with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not decrypt PGP data.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:659
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:117

3) Horde_Crypt_Pgp_BinaryTest::testPgpEncrypt with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not PGP encrypt message.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:595
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:149

4) Horde_Crypt_Pgp_BinaryTest::testPgpEncryptSymmetric with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not PGP encrypt message.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:595
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:182

5) Horde_Crypt_Pgp_BinaryTest::testPgpPacketInformation with data set #0 (Horde_Crypt_Pgp Object (...))
PHPUnit_Framework_Exception: Argument #2 (No Value) of PHPUnit_Framework_Assert::assertArrayHasKey() must be a array or ArrayAccess

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:236

6) Horde_Crypt_Pgp_BinaryTest::testPgpPacketSignature with data set #0 (Horde_Crypt_Pgp Object (...))
Undefined index: keyid

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:290

7) Horde_Crypt_Pgp_BinaryTest::testPgpPacketSignatureByUidIndex with data set #0 (Horde_Crypt_Pgp Object (...))
Undefined index: keyid

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:326

8) Horde_Crypt_Pgp_BinaryTest::testPgpSign with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not PGP sign message.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:595
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:479

9) Horde_Crypt_Pgp_BinaryTest::testVerifyPassphraseCorrect with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not determine the recipient's e-mail address.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:431
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:578

10) Horde_Crypt_Pgp_BinaryTest::testVerifyPassphraseIncorrect with data set #0 (Horde_Crypt_Pgp Object (...))
Horde_Crypt_Exception: Could not determine the recipient's e-mail address.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/lib/Horde/Crypt/Pgp.php:431
/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:592

--

There were 6 failures:

1) Horde_Crypt_Pgp_BinaryTest::testBug6601 with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Name:             Richard Selsky
-Key Type:         Public Key
-Key Creation:     04/11/08
-Expiration Date:  04/11/13
-Key Length:       1024 Bytes
-Comment:          [None]
-E-Mail:           rselsky@bu.edu
-Hash-Algorithm:   pgp-sha1
-Key ID:           0xF3C01D42
-Key Fingerprint:  5912D91D4C79C6701FFF148604A67B37F3C01D42
-
-'
+''

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:65

2) Horde_Crypt_Pgp_BinaryTest::testPgpEncryptedSymmetrically with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that false is true.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:212

3) Horde_Crypt_Pgp_BinaryTest::testGetSignersKeyID with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that null matches expected 'BADEABD7'.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:223

4) Horde_Crypt_Pgp_BinaryTest::testPgpPrettyKey with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Name:             My Name
-Key Type:         Public Key
-Key Creation:     08/11/06
-Expiration Date:  [Never]
-Key Length:       1024 Bytes
-Comment:          My Comment
-E-Mail:           me@example.com
-Hash-Algorithm:   pgp-sha1
-Key ID:           0xBADEABD7
-Key Fingerprint:  966F4BA9569DE6F65E8253977CA74426BADEABD7
-
-'
+''

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:371

5) Horde_Crypt_Pgp_BinaryTest::testPgpGetFingerprintsFromKey with data set #0 (Horde_Crypt_Pgp Object (...), array('966F4BA9569DE6F65E8253977CA74...DEABD7'), '-----BEGIN PGP PUBLIC KEY BLO...-----\n', array('966F4BA9569DE6F65E8253977CA74...DEABD7'), '-----BEGIN PGP PRIVATE KEY BL...-----\n')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    '0xBADEABD7' => '966F4BA9569DE6F65E8253977CA74...DEABD7'
 )

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:398

6) Horde_Crypt_Pgp_BinaryTest::testGetPublicKeyFromPrivateKey with data set #0 (Horde_Crypt_Pgp Object (...))
Failed asserting that null is not null.

/builddir/build/BUILD/php-horde-Horde-Crypt-2.7.7/Horde_Crypt-2.7.7/test/Horde/Crypt/Pgp/TestBase.php:603

ERRORS!
Tests: 20, Assertions: 21, Errors: 10, Failures: 6.

```