### PR TITLE
run test in separate process, for PHP 7.2

### DIFF
--- a/framework/Core/test/Horde/Core/UrlTest.php
+++ b/framework/Core/test/Horde/Core/UrlTest.php
@@ -8,6 +8,9 @@
  */
 class Horde_Core_UrlTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @runInSeparateProcess
+     */
     public function testUrl()
     {
         $sname = session_name();
@@ -318,6 +321,9 @@ class Horde_Core_UrlTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testSelfUrl()
     {
         $GLOBALS['registry'] = new Registry();


### PR DESCRIPTION
Without this change:

```
There were 2 errors:

1) Horde_Core_UrlTest::testUrl
session_name(): Cannot change session name when headers already sent

/work/GIT/horde/framework/Core/test/Horde/Core/UrlTest.php:13

2) Horde_Core_UrlTest::testSelfUrl
session_name(): Cannot change session name when headers already sent

/work/GIT/horde/framework/Core/test/Horde/Core/UrlTest.php:328
```