### PR TITLE
Removed sort when cutting results

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Socket.php
@@ -2537,7 +2537,6 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
             $partial = $this->getIdsOb($options['partial'], true);
             $min = $partial->min - 1;
 
-            $sr->sort();
             $sr = $this->getIdsOb(
                 array_slice($sr->ids, $min, $partial->max - $min),
                 !empty($options['sequence'])


### PR DESCRIPTION
Removed a sort of Horde_Imap_Client_Ids when cutting (partial) the result of a search. This sort it's unnecessary and broke the sorting done previously.