### PR TITLE
Check is QRESYNC ENABLED

### DIFF
--- a/framework/Imap_Client/lib/Horde/Imap/Client/Base.php
+++ b/framework/Imap_Client/lib/Horde/Imap/Client/Base.php
@@ -2790,7 +2790,7 @@ implements Serializable, SplObserver
         $this->login();
 
         if (empty($opts['ids'])) {
-            if (!$this->_capability('QRESYNC')) {
+            if (!$this->_capability()->isEnabled('QRESYNC')) {
                 return $this->getIdsOb();
             }
             $opts['ids'] = $this->getIdsOb(Horde_Imap_Client_Ids::ALL);
@@ -2802,7 +2802,7 @@ implements Serializable, SplObserver
 
         $this->openMailbox($mailbox, Horde_Imap_Client::OPEN_AUTO);
 
-        if ($this->_capability('QRESYNC')) {
+        if ($this->_capability()->isEnabled('QRESYNC')) {
             if (!$this->_mailboxOb()->getStatus(Horde_Imap_Client::STATUS_HIGHESTMODSEQ)) {
                 throw new Horde_Imap_Client_Exception(
                     Horde_Imap_Client_Translation::r("Mailbox does not support mod-sequences."),


### PR DESCRIPTION
Exception: Error in IMAP command UID FETCH: QRESYNC not enabled (0.000 + 0.000 secs).
From https://tools.ietf.org/html/rfc5162 :
A client making use of this extension MUST issue "ENABLE QRESYNC" once it is authenticated.  A server MUST respond with a tagged BAD response if the QRESYNC parameter to the SELECT/EXAMINE command or the VANISHED UID FETCH modifier is specified and the client hasn't issued "ENABLE QRESYNC" in the current connection.