### PR TITLE
Expose Horde Api calendars (timeobjects) to DAV in readonly mode

### DIFF
--- a/kronolith/lib/Calendar/External.php
+++ b/kronolith/lib/Calendar/External.php
@@ -96,6 +96,24 @@ class Kronolith_Calendar_External extends Kronolith_Calendar
     {
         return $this->_api;
     }
+   /**
+     * Returns the CalDAV URL to this calendar.
+     *
+     * @return string  This calendar's CalDAV URL.
+     */
+    public function caldavUrl()
+    {
+        return $this->_caldavUrl($this->internalId(), 'calendar');
+    }
+
+    /**
+     * Create a dav compatible internalId string
+     *
+     */
+    public function internalId()
+    {
+        return sprintf("external:%s:%s", $this->_api, str_replace('/', ':', $this->_id));
+    }
 
     /**
      * Returns a hash representing this calendar.


### PR DESCRIPTION
Expose Horde Api calendars (timeobjects) to DAV in readonly mode
Omit tasks as they already have their own backend.

Please review Kronolith_Application::davGetCollections for the principal of the "external" shares - should it be -system- or the current user?

Tested this patch against a production horde 5.2 but there is no real difference with current master.