### PR TITLE
fix pgp key lookup if more than one key is found

### DIFF
--- a/imp/lib/Pgp.php
+++ b/imp/lib/Pgp.php
@@ -359,7 +359,7 @@ class IMP_Pgp
          * the array. There is no way of knowing which is the "preferred" key,
          * if the keys are different. */
         if (is_array($result)) {
-            reset($result);
+            $result = reset($result);
         }
 
         return $result;


### PR DESCRIPTION
reset() *returns* the first element, so let's actually do what the
comment above says.