### PR TITLE
ingo: Add support for boolean spam headers

### DIFF
--- a/ingo/config/conf.xml
+++ b/ingo/config/conf.xml
@@ -39,6 +39,12 @@
     &quot;*&quot;, then &quot;****&quot; in the header indicates a spam level
     of four.">*</configstring>
    </case>
+   <case name="boolean" desc="Boolean">
+    <configstring name="header" desc="The spam header to
+    check">X-Spam</configstring>
+    <configstring name="value" desc="The value of the spam header when a mail
+    is identified as spam.">Yes</configstring>
+   </case>
   </configswitch>
  </configsection>
 </configuration>

--- a/ingo/lib/Factory/Script.php
+++ b/ingo/lib/Factory/Script.php
@@ -86,6 +86,10 @@ class Ingo_Factory_Script extends Horde_Core_Factory_Base
             ($params['spam_compare'] == 'string')) {
             $params['spam_char'] = $conf['spam']['char'];
         }
+        if (!isset($params['spam_value']) &&
+            ($params['spam_compare'] == 'boolean')) {
+            $params['spam_value'] = $conf['spam']['value'];
+        }
 
         switch ($driver) {
         case 'Imap':

--- a/ingo/lib/Form/Spam.php
+++ b/ingo/lib/Form/Spam.php
@@ -30,17 +30,21 @@ class Ingo_Form_Spam extends Ingo_Form_Base
 
     public function __construct($vars, $title = '', $name = null)
     {
+        global $conf;
+
         parent::__construct($vars, $title, $name);
 
-        $v = $this->addVariable(
-            _("Spam Level:"),
-            'level',
-            'int',
-            true,
-            false,
-            _("Messages with a likely spam score greater than or equal to this number will be treated as spam.")
-        );
-        $v->setHelp('spam-level');
+        if ($conf['spam']['compare'] != 'boolean') {
+            $v = $this->addVariable(
+                _("Spam Level:"),
+                'level',
+                'int',
+                true,
+                false,
+                _("Messages with a likely spam score greater than or equal to this number will be treated as spam.")
+            );
+            $v->setHelp('spam-level');
+        }
 
         $this->folder_var = $this->addVariable(
             _("Folder to receive spam:"),

--- a/ingo/lib/Script/Maildrop.php
+++ b/ingo/lib/Script/Maildrop.php
@@ -358,6 +358,12 @@ class Ingo_Script_Maildrop extends Ingo_Script_Base
                     $rule->level
                 )
             ));
+        } elseif ($this->_params['spam_compare'] == 'boolean') {
+            $recipe->addCondition(array(
+                'match' => 'is',
+                'field' => $this->_params['spam_header'],
+                'value' => $this->_params['spam_value']
+            ));
         }
 
         $this->_addItem(Ingo::RULE_SPAM, $recipe);

--- a/ingo/lib/Script/Sieve.php
+++ b/ingo/lib/Script/Sieve.php
@@ -467,6 +467,14 @@ class Ingo_Script_Sieve extends Ingo_Script_Base
                 'comparator' => 'i;ascii-casemap',
             );
             $test = new Ingo_Script_Sieve_Test_Header($vals);
+        } elseif ($this->_params['spam_compare'] == 'boolean') {
+            $vals = array(
+                'headers' => $this->_params['spam_header'],
+                'match-type' => ':is',
+                'strings' => $this->_params['spam_value'],
+                'comparator' => 'i;ascii-casemap',
+            );
+            $test = new Ingo_Script_Sieve_Test_Header($vals);
         }
 
         $actions[] = new Ingo_Script_Sieve_Action_Stop();


### PR DESCRIPTION
This PR adds support for boolean (yes/no) spam headers (such as those used by rspamd) to Ingo.

I have confirmed that the correct sieve rule is generated but am unable to test maildrop.