### PR TITLE
Fix quota int value

### DIFF
--- a/imp/lib/Ajax/Queue.php
+++ b/imp/lib/Ajax/Queue.php
@@ -290,7 +290,7 @@ class IMP_Ajax_Queue
             ($quotadata = $injector->getInstance('IMP_Quota_Ui')->quota($this->_quota[0], $this->_quota[1]))) {
             $ajax->addTask('quota', array(
                 'm' => $quotadata['message'],
-                'p' => round($quotadata['percent']),
+                'p' => round($quotadata['raw_percent']),
                 'l' => $quotadata['percent'] >= 90
                     ? 'alert'
                     : ($quotadata['percent'] >= 75 ? 'warn' : '')

--- a/imp/lib/Quota/Ui.php
+++ b/imp/lib/Quota/Ui.php
@@ -93,9 +93,9 @@ class IMP_Quota_Ui
             $quota['usage'] = $quota['usage'] / $calc;
             $quota['limit'] = $quota['limit'] / $calc;
             $ret['raw_percent'] = ($quota['usage'] * 100) / $quota['limit'];
-            if ($ret['percent'] >= 90) {
+            if ($ret['raw_percent'] >= 90) {
                 $ret['class'] = 'quotaalert';
-            } elseif ($ret['percent'] >= 75) {
+            } elseif ($ret['raw_percent'] >= 75) {
                 $ret['class'] = 'quotawarn';
             }
 

--- a/imp/lib/Quota/Ui.php
+++ b/imp/lib/Quota/Ui.php
@@ -85,21 +85,22 @@ class IMP_Quota_Ui
         list($calc, $unit) = $quotaDriver->getUnit();
         $ret = array(
             'class' => '',
-            'percent' => 0
+            'percent' => 0,
+            'raw_percent' => 0
         );
 
         if ($quota['limit'] != 0) {
             $quota['usage'] = $quota['usage'] / $calc;
             $quota['limit'] = $quota['limit'] / $calc;
-            $ret['percent'] = ($quota['usage'] * 100) / $quota['limit'];
+            $ret['raw_percent'] = ($quota['usage'] * 100) / $quota['limit'];
             if ($ret['percent'] >= 90) {
                 $ret['class'] = 'quotaalert';
             } elseif ($ret['percent'] >= 75) {
                 $ret['class'] = 'quotawarn';
             }
 
-            $ret['message'] = sprintf($strings['short'], $ret['percent'], $quota['limit'], $unit);
-            $ret['percent'] = sprintf("%.2f", $ret['percent']);
+            $ret['message'] = sprintf($strings['short'], $ret['raw_percent'], $quota['limit'], $unit);
+            $ret['percent'] = sprintf("%.2f", $ret['raw_percent']);
         } elseif ($quotaDriver->isHiddenWhenUnlimited()) {
             return false;
         } elseif ($quota['usage'] != 0) {


### PR DESCRIPTION
`$ret['percent']` is a string `sprintf("%.2f", $ret['raw_percent']);`
This keep actual API, but fix the round calc.